### PR TITLE
Added main modules as exports

### DIFF
--- a/src/sympc/__init__.py
+++ b/src/sympc/__init__.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 from pkg_resources import get_distribution, DistributionNotFound
 
+from . import config  # noqa: 401
+from . import encoder  # noqa: 401
+from . import protocol  # noqa: 401
+from . import session  # noqa: 401
+from . import tensor  # noqa: 401
+
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -1,0 +1,9 @@
+import sympc
+
+
+def test_imports() -> None:
+    sympc.config
+    sympc.encoder
+    sympc.protocol
+    sympc.session
+    sympc.tensor


### PR DESCRIPTION
## Description
Addressing issues in PySyft branch where submodule dot syntax not working.
- Added main modules as exports
- Added test to make sure exported modules are working

## Affected Dependencies
None

## How has this been tested?
I created a test

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
