### PR TITLE
Convert last step

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.7
+# python_requires = >=3.7
 
 [options.packages.find]
 where = src

--- a/src/sympc/encoder/fp_encoder.py
+++ b/src/sympc/encoder/fp_encoder.py
@@ -50,7 +50,7 @@ class FixedPointEncoder:
         """
 
         if not isinstance(value, torch.Tensor):
-            value = torch.tensor(data=[value], dtype=torch.long)
+            value = torch.tensor(data=[value])
 
         # Use the largest type
         long_value = (value * self._scale).long()


### PR DESCRIPTION
## Description
Convert to long tensor when returning the value such that when we encode a float value, we would not lose precision during the conversation to long tensor (we would still lose some precision during the last step when we convert ```scale * tensor``` to long)

## Affected Dependencies
Testing with float values.

## How has this been tested?
- Tests to be added in a subsequent PR

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
