### PR TITLE
Fix mypy line in test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,6 @@ jobs:
           flake8 --config=.flake8 .
           black --check .
           # Run type checker in CI such that type errors can be identified and gradually addressed.
-          # Once all existing type errors are addressed, the `|| echo` after the mypy call can be removed.
-          mypy src || echo "Type errors found, continuing build..."
       - name: Check docstring coverage
         run: |
           interrogate -mvp src/ -f 52.5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,12 +56,15 @@ jobs:
           pip3 install pep8-naming
           pip3 install interrogate
           pip3 install black
+          python3 -m pip install mypy
       - name: Lint, format, and type-check
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 --config=.flake8 .
           black --check .
           # Run type checker in CI such that type errors can be identified and gradually addressed.
+          # Once all existing type errors are addressed, the `|| echo` after the mypy call can be removed.
+          mypy src || echo "Type errors found, continuing build..."
       - name: Check docstring coverage
         run: |
           interrogate -mvp src/ -f 52.5


### PR DESCRIPTION
## Description

It looks like the `mypy` command is not being found. For example, see [this](https://github.com/OpenMined/SyMPC/pull/15/checks?check_run_id=1568386019) run or [this](https://github.com/OpenMined/SyMPC/runs/1545245419) run.

This PR adds a line to install `mypy` correctly.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
