### PR TITLE
Split Session into Session and SessionManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+
+# VSCode
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ tags
 # Unittest and coverage
 htmlcov/*
 .coverage
+.coverage.*
 .tox
 junit.xml
 coverage.xml

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,6 +33,7 @@
     "import torch\n",
     "\n",
     "from sympc.session import Session\n",
+    "from sympc.session import SessionManager\n",
     "from sympc.tensor import MPCTensor"
    ]
   },
@@ -45,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +64,7 @@
     "\n",
     "# Setup the session for the computation\n",
     "session = Session(parties=parties)\n",
-    "Session.setup_mpc(session)"
+    "SessionManager.setup_mpc(session)"
    ]
   },
   {
@@ -222,7 +223,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (sympc)",
+   "display_name": "sympc",
    "language": "python",
    "name": "sympc"
   },
@@ -236,9 +237,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ isort==5.6.4
 mypy==0.790
 pep8-naming==0.11.1
 pytest-cov==2.10.1
-git+git://github.com/OpenMined/PySyft.git@sympc-dev#egg=syft
+git+git://github.com/OpenMined/PySyft.git@0.4#egg=syft

--- a/src/sympc/session/__init__.py
+++ b/src/sympc/session/__init__.py
@@ -1,10 +1,8 @@
-"""
-Session class and utility functions used in conjunction with the
-session
-"""
+"""Session class and utility functions used in conjunction with the session."""
 
 from .session import Session
+from .session_manager import SessionManager
 from .utils import get_generator
 from .utils import get_type_from_ring
 
-__all__ = ["Session", "get_type_from_ring", "get_generator"]
+__all__ = ["Session", "SessionManager", "get_type_from_ring", "get_generator"]

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -17,6 +17,7 @@ Example:
 # stdlib
 import operator
 from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
@@ -118,6 +119,9 @@ class Session:
         # Some protocols require a trusted third party
         # Ex: SPDZ
         self.trusted_third_party = ttp
+        # The CryptoStore is initialized at each party when it is unserialized
+        self.crypto_store: Dict[Any, Any] = {}  # TODO: this should be CryptoStore
+        self.protocol: Optional[str] = None
 
         self.config = config if config else Config()
 

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -184,9 +184,6 @@ class Session:
         if not isinstance(other, self.__class__):
             return False
 
-        if self.__slots__ != other.__slots__:  # pragma: no cover
-            return False
-
         attr_getters = [
             operator.attrgetter(attr) for attr in self.__slots__ - Session.NOT_COMPARE
         ]

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -2,7 +2,7 @@
 The implementation for the Session
 It is used to identify a MPC computation done between multiple parties
 
-This would be used in case a party is involved in multipl MPC session,
+This would be used in case a party is involved in multiple MPC session,
 this one is used to identify in which one is used
 
 Example:

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -1,8 +1,5 @@
-"""The implementation for the Session It is used to identify a MPC computation
+"""The implementation for the Session. It is used to identify a MPC computation
 done between multiple parties.
-
-This would be used in case a party is involved in multiple MPC session,
-this one is used to identify in which one is used
 
 Example:
     Alice Bob and John wants to do some computation

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -1,6 +1,5 @@
-"""
-The implementation for the Session
-It is used to identify a MPC computation done between multiple parties
+"""The implementation for the Session It is used to identify a MPC computation
+done between multiple parties.
 
 This would be used in case a party is involved in multiple MPC session,
 this one is used to identify in which one is used
@@ -34,8 +33,7 @@ from sympc.session.utils import get_type_from_ring
 
 
 class Session:
-    """
-    Class used to keep information about computation done in SMPC
+    """Class used to keep information about computation done in SMPC.
 
     Arguments:
         parties (Optional[List[Any]): used to send/receive messages
@@ -104,7 +102,7 @@ class Session:
         ttp: Optional[Any] = None,
         uuid: Optional[UUID] = None,
     ) -> None:
-        """ Initializer for the Session """
+        """Initializer for the Session."""
 
         self.uuid = uuid4() if uuid is None else uuid
 
@@ -127,7 +125,7 @@ class Session:
         self.trusted_third_party = ttp
 
         # The CryptoStore is initialized at each party when it is unserialized
-        self.crypto_store: Dict[Any, Any] = {}  # TODO: this should be CryptoStore
+        self.crypto_store: Dict[Any, Any] = None  # TODO: this should be CryptoStore
 
         self.protocol: Optional[str] = None
 
@@ -153,9 +151,8 @@ class Session:
     def przs_generate_random_share(
         self, shape: Union[tuple, torch.Size], generators: List[torch.Generator]
     ) -> Any:
-        """Generate a random share using the two generators that are
-        hold by a party.
-        """
+        """Generate a random share using the two generators that are hold by a
+        party."""
 
         from sympc.tensor import ShareTensor
 
@@ -179,9 +176,8 @@ class Session:
         return share
 
     def __eq__(self, other: Any) -> bool:
-        """
-        Check if "self" is equal with another object given a set of attributes
-        to compare.
+        """Check if "self" is equal with another object given a set of
+        attributes to compare.
 
         :return: if self and other are equal
         :rtype: bool

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -184,7 +184,7 @@ class Session:
         if not isinstance(other, self.__class__):
             return False
 
-        if self.__slots__ != other.__slots__:
+        if self.__slots__ != other.__slots__:  # pragma: no cover
             return False
 
         attr_getters = [

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -2,7 +2,7 @@
 The implementation for the Session
 It is used to identify a MPC computation done between multiple parties
 
-This would be used in case a party is involved in multipel MPC session,
+This would be used in case a party is involved in multipl MPC session,
 this one is used to identify in which one is used
 
 Example:

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -98,6 +98,7 @@ class Session:
         parties: Optional[List[Any]] = None,
         ring_size: int = 2 ** 64,
         config: Optional[Config] = None,
+        ttp: Optional[Any] = None,
         uuid: Optional[UUID] = None,
     ) -> None:
         """ Initializer for the Session """
@@ -113,6 +114,10 @@ class Session:
             self.parties = []
         else:
             self.parties = parties
+
+        # Some protocols require a trusted third party
+        # Ex: SPDZ
+        self.trusted_third_party = ttp
 
         self.config = config if config else Config()
 

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -122,7 +122,9 @@ class Session:
         self.trusted_third_party = ttp
 
         # The CryptoStore is initialized at each party when it is unserialized
-        self.crypto_store: Dict[Any, Any] = None  # TODO: this should be CryptoStore
+        self.crypto_store: Optional[
+            Dict[Any, Any]
+        ] = None  # TODO: this should be CryptoStore
 
         self.protocol: Optional[str] = None
 

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -109,8 +109,5 @@ class SessionManager:
         if not isinstance(other, self.__class__):
             return False
 
-        if self.__slots__ != other.__slots__:  # pragma: no cover
-            return False
-
         attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
         return all(getter(self) == getter(other) for getter in attr_getters)

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -109,7 +109,7 @@ class SessionManager:
         if not isinstance(other, self.__class__):
             return False
 
-        if self.__slots__ != other.__slots__:
+        if self.__slots__ != other.__slots__:  # pragma: no cover
             return False
 
         attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -76,7 +76,7 @@ class SessionManager:
         2 parties will generate the same random number at a given moment:
         - Party 1 holds G1 and G2
         - Party 2 holds G2 and G3
-        - Party 3 holds G3 and
+        - Party 3 holds G3 and G1
 
         Step 2: When they generate a PRZS:
             Party 1 generates: Next(G1) - Next(G2)

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -78,7 +78,6 @@ class SessionManager:
 
     def __init__(
         self,
-        ttp: Optional[Any] = None,
         uuid: Optional[UUID] = None,
     ) -> None:
         """ Initializer for the Session """
@@ -88,10 +87,6 @@ class SessionManager:
         # Each worker will have the rank as the index in the list
         # Only the party that is the CC (Control Center) will have access
         # to this
-
-        # Some protocols require a trusted third party
-        # Ex: SPDZ
-        self.trusted_third_party = ttp
 
         self.crypto_store: Dict[Any, Any] = {}
         self.protocol: Optional[str] = None

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -31,14 +31,7 @@ class SessionManager:
         uuid (Optional[UUID]): used to identify a session
     """
 
-    # Those values are not used at comparison
-    NOT_COMPARE = {"id", "description", "tags"}
-
     __slots__ = {
-        # Populated in Syft
-        "id",
-        "tags",
-        "description",
         "uuid",
     }
 
@@ -55,7 +48,7 @@ class SessionManager:
         # to this
 
     @staticmethod
-    def setup_mpc(session: "Session") -> None:
+    def setup_mpc(session: Session) -> None:
         """Must be called to send the session to all other parties involved in
         the computation."""
         for rank, party in enumerate(session.parties):
@@ -66,7 +59,7 @@ class SessionManager:
         SessionManager._setup_przs(session)
 
     @staticmethod
-    def _setup_przs(session: "Session") -> None:
+    def _setup_przs(session: Session) -> None:
         """Setup the Pseudo-Random-Zero-Share generators to the parties
         involved in the communication.
 
@@ -119,7 +112,5 @@ class SessionManager:
         if self.__slots__ != other.__slots__:
             return False
 
-        attr_getters = [
-            operator.attrgetter(attr) for attr in self.__slots__ - Session.NOT_COMPARE
-        ]
+        attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
         return all(getter(self) == getter(other) for getter in attr_getters)

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -8,7 +8,6 @@ This class holds the static methods used for the Session.
 import operator
 import secrets
 from typing import Any
-from typing import Dict
 from typing import Optional
 from uuid import UUID
 from uuid import uuid4
@@ -68,7 +67,6 @@ class SessionManager:
         "protocol",
         "config",
         "przs_generators",
-        "rank",
         "session_ptrs",
         "ring_size",
         "min_value",
@@ -87,9 +85,6 @@ class SessionManager:
         # Each worker will have the rank as the index in the list
         # Only the party that is the CC (Control Center) will have access
         # to this
-
-        self.crypto_store: Dict[Any, Any] = {}
-        self.protocol: Optional[str] = None
 
     @staticmethod
     def setup_mpc(session: "Session") -> None:

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -1,5 +1,4 @@
-"""
-The implementation for the SessionManager.
+"""The implementation for the SessionManager.
 
 This class holds the static methods used for the Session.
 """
@@ -16,15 +15,10 @@ from sympc.session.session import Session
 
 
 class SessionManager:
-    """
-    Class used to manage sessions.
+    """Class used to manage sessions.
 
     Arguments:
-        ring_size (int): field used for the operations applied on the shares
-        config (Optional[Config]): configuration used for information needed
-            by the Fixed Point Encoder
-        ttp (Optional[Any]): trusted third party
-        uuid (Optional[UUID]): used to identify a session
+        uuid (Optional[UUID]): used to identify a session manager instance.
 
     Attributes:
         Syft Serializable Attributes
@@ -35,25 +29,10 @@ class SessionManager:
 
 
         uuid (Optional[UUID]): used to identify a session
-        parties (Optional[List[Any]): used to send/receive messages
-        trusted_third_party (Optional[Any]): the trusted third party
-        crypto_store (Dict[Any, Any]): keep track of items needed in MPC (for the moment not used)
-        protocol (Optional[str]): specify what protocol to register for a session
-        config (Config): used for the Fixed Precision Encoder
-        przs_generator (Optional[torch.Generator]): Pseudo-Random-Zero-Share Generators
-            pointers to the parties generators
-        rank (int): Rank for a party in this session
-        sessio_ptrs (List[Session]): pointers to the session that should be identical to the
-            one we have
-        ring_size (int): field used for the operations applied on the shares
-        min_value (int): the minimum value allowed for tensors' values
-        max_value (int): the maximum value allowed for tensors' values
-        tensor_type (Union[torch.dtype): tensor type used in the computation, this is used
-            such that we get the "modulo" operation for free
     """
 
     # Those values are not used at comparison
-    NOT_COMPARE = {"id", "description", "tags", "parties"}
+    NOT_COMPARE = {"id", "description", "tags"}
 
     __slots__ = {
         # Populated in Syft
@@ -61,24 +40,13 @@ class SessionManager:
         "tags",
         "description",
         "uuid",
-        "parties",
-        "trusted_third_party",
-        "crypto_store",
-        "protocol",
-        "config",
-        "przs_generators",
-        "session_ptrs",
-        "ring_size",
-        "min_value",
-        "max_value",
-        "tensor_type",
     }
 
     def __init__(
         self,
         uuid: Optional[UUID] = None,
     ) -> None:
-        """ Initializer for the Session """
+        """Initializer for the Session."""
 
         self.uuid = uuid4() if uuid is None else uuid
 
@@ -88,9 +56,8 @@ class SessionManager:
 
     @staticmethod
     def setup_mpc(session: "Session") -> None:
-        """Must be called to send the session to all other parties involved in the
-        computation.
-        """
+        """Must be called to send the session to all other parties involved in
+        the computation."""
         for rank, party in enumerate(session.parties):
             # Assign a new rank before sending it to another party
             session.rank = rank
@@ -100,8 +67,8 @@ class SessionManager:
 
     @staticmethod
     def _setup_przs(session: "Session") -> None:
-        """Setup the Pseudo-Random-Zero-Share generators to the parties involved
-        in the communication.
+        """Setup the Pseudo-Random-Zero-Share generators to the parties
+        involved in the communication.
 
         Assume there are 3 parties:
 
@@ -140,9 +107,8 @@ class SessionManager:
             session.przs_generators[next_rank][0] = gen_next
 
     def __eq__(self, other: Any) -> bool:
-        """
-        Check if "self" is equal with another object given a set of attributes
-        to compare.
+        """Check if "self" is equal with another object given a set of
+        attributes to compare.
 
         :return: if self and other are equal
         :rtype: bool

--- a/tests/sympc/session/session_manager_test.py
+++ b/tests/sympc/session/session_manager_test.py
@@ -1,0 +1,49 @@
+"""Tests for the SessionManager class."""
+
+# stdlib
+from uuid import UUID
+from uuid import uuid4
+
+from sympc.session import Session
+from sympc.session import SessionManager
+
+
+def test_session_manager_init():
+    """Test correct initialisation of the SessionManager class."""
+    # Test default init
+    session = SessionManager()
+    assert isinstance(session.uuid, UUID)
+    # Test custom init
+    uuid = uuid4()
+    session = Session(uuid=uuid)
+    assert session.uuid == uuid
+
+
+def test_setup_mpc(get_clients):
+    """Test setup_mpc method for session."""
+    alice_client, bob_client = get_clients(2)
+    session = Session(parties=[alice_client, bob_client])
+    SessionManager.setup_mpc(session)
+    assert session.rank == 1
+    assert len(session.session_ptrs) == 2
+
+
+def test_setup_przs(get_clients):
+    """Test _setup_przs method for session."""
+    alice_client, bob_client = get_clients(2)
+    session = Session(parties=[alice_client, bob_client])
+    SessionManager._setup_przs(session)
+    assert True
+
+
+def test_eq():
+    """Test __eq__ for SessionManager."""
+    session_manager = SessionManager()
+    other1 = SessionManager()
+    other2 = session_manager
+    # Test different instances:
+    assert session_manager != 1
+    # Test different session_managers:
+    assert session_manager != other1
+    # Test equal session_managers:
+    assert session_manager == other2

--- a/tests/sympc/session/session_manager_test.py
+++ b/tests/sympc/session/session_manager_test.py
@@ -32,8 +32,9 @@ def test_setup_przs(get_clients):
     """Test _setup_przs method for session."""
     alice_client, bob_client = get_clients(2)
     session = Session(parties=[alice_client, bob_client])
+    assert len(session.przs_generators) == 0
     SessionManager._setup_przs(session)
-    assert True
+    assert len(session.przs_generators) == 2
 
 
 def test_eq():

--- a/tests/sympc/session/session_test.py
+++ b/tests/sympc/session/session_test.py
@@ -9,6 +9,8 @@ import torch
 
 from sympc.config import Config
 from sympc.session import Session
+from sympc.session import SessionManager
+from sympc.session.utils import get_generator
 from sympc.session.utils import get_type_from_ring
 from sympc.tensor import ShareTensor
 
@@ -51,13 +53,17 @@ def test_session_init():
     assert session.max_value == (2 ** 32 - 1) // 2
 
 
-def test_przs_generate_random_share():
+def test_przs_generate_random_share(get_clients):
     """Test przs_generate_random_share method from Session."""
     session = Session()
-    generators = [torch.Generator(), torch.Generator()]
-    share = session.przs_generate_random_share(shape=(1, 2), generators=generators)
+    SessionManager.setup_mpc(session)
+    gen1 = get_generator(42)
+    gen2 = get_generator(43)
+    generators = [gen1, gen2]
+    share = session.przs_generate_random_share(shape=(2, 1), generators=generators)
     assert isinstance(share, ShareTensor)
-    assert (share.tensor == torch.tensor([0, 0])).all()
+    target_tensor = torch.tensor(([-1540733531777602634], [2813554787685566880]))
+    assert (share.tensor == target_tensor).all()
 
 
 def test_eq():

--- a/tests/sympc/session/session_test.py
+++ b/tests/sympc/session/session_test.py
@@ -1,0 +1,73 @@
+"""Tests for the Session class."""
+
+# stdlib
+from uuid import UUID
+from uuid import uuid4
+
+# third party
+import torch
+
+from sympc.config import Config
+from sympc.session import Session
+from sympc.session.utils import get_type_from_ring
+from sympc.tensor import ShareTensor
+
+
+def test_session_init():
+    """Test correct initialisation of the Sessin class."""
+    # Test default init
+    session = Session()
+    assert isinstance(session.uuid, UUID)
+    assert session.parties == []
+    assert session.trusted_third_party is None
+    assert session.crypto_store is None
+    assert session.protocol is None
+    assert isinstance(session.config, Config)
+    assert session.przs_generators == []
+    assert session.rank == -1
+    assert session.session_ptrs == []
+    assert session.tensor_type == get_type_from_ring(2 ** 64)
+    assert session.ring_size == 2 ** 64
+    assert session.min_value == -(2 ** 64) // 2
+    assert session.max_value == (2 ** 64 - 1) // 2
+    # Test custom init
+    uuid = uuid4()
+    config = Config()
+    session = Session(
+        parties=["alice", "bob"], ring_size=2 ** 32, config=config, ttp="TTP", uuid=uuid
+    )
+    assert session.uuid == uuid
+    assert session.parties == ["alice", "bob"]
+    assert session.trusted_third_party == "TTP"
+    assert session.crypto_store is None
+    assert session.protocol is None
+    assert session.config == config
+    assert session.przs_generators == []
+    assert session.rank == -1
+    assert session.session_ptrs == []
+    assert session.tensor_type == get_type_from_ring(2 ** 32)
+    assert session.ring_size == 2 ** 32
+    assert session.min_value == -(2 ** 32) // 2
+    assert session.max_value == (2 ** 32 - 1) // 2
+
+
+def test_przs_generate_random_share():
+    """Test przs_generate_random_share method from Session."""
+    session = Session()
+    generators = [torch.Generator(), torch.Generator()]
+    share = session.przs_generate_random_share(shape=(1, 2), generators=generators)
+    assert isinstance(share, ShareTensor)
+    assert (share.tensor == torch.tensor([0, 0])).all()
+
+
+def test_eq():
+    """Test __eq__ for Session."""
+    session = Session()
+    other1 = Session()
+    other2 = session
+    # Test different instances:
+    assert session != 1
+    # Test different sessions:
+    assert session != other1
+    # Test equal sessions:
+    assert session == other2

--- a/tests/sympc/store/crypto_primitive_provider_test.py
+++ b/tests/sympc/store/crypto_primitive_provider_test.py
@@ -10,6 +10,7 @@ from typing import Tuple
 import pytest
 
 from sympc.session import Session
+from sympc.session import SessionManager
 from sympc.store import CryptoPrimitiveProvider
 from sympc.store import register_primitive_generator
 from sympc.store import register_primitive_store_add
@@ -20,9 +21,9 @@ PRIMITIVE_NR_ELEMS = 4
 
 @register_primitive_generator("test")
 def provider_test(nr_parties: int) -> List[Tuple[int]]:
-    """
-    This function will generate the values
-    ([0, 1, ...], [0, 1, ...], [0, 1, ...], [0, 1, ...])
+    """This function will generate the values ([0, 1, ...], [0, 1, ...], [0, 1,
+
+    ...], [0, 1, ...])
 
     And the CryptoProvider will arrange them like:
 
@@ -59,7 +60,7 @@ def test_generate_primitive_exception() -> None:
 
 def test_transfer_primitives_type_exception() -> None:
     with pytest.raises(ValueError):
-        """Primitives should be a list"""
+        """Primitives should be a list."""
         CryptoPrimitiveProvider._transfer_primitives_to_parties(
             op_str="test", primitives=50, sessions=[], p_kwargs={}
         )
@@ -67,7 +68,7 @@ def test_transfer_primitives_type_exception() -> None:
 
 def test_transfer_primitives_mismatch_len_exception() -> None:
     with pytest.raises(ValueError):
-        """Primitives and Sesssions should have the same len"""
+        """Primitives and Sesssions should have the same len."""
         CryptoPrimitiveProvider._transfer_primitives_to_parties(
             op_str="test", primitives=[1], sessions=[], p_kwargs={}
         )
@@ -88,7 +89,7 @@ def test_generate_primitive(
 ) -> None:
     parties = get_clients(nr_parties)
     session = Session(parties=parties)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     g_kwargs = {"nr_parties": nr_parties}
     res = CryptoPrimitiveProvider.generate_primitives(
@@ -113,7 +114,7 @@ def test_generate_and_transfer_primitive(
 ) -> None:
     parties = get_clients(nr_parties)
     session = Session(parties=parties)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     g_kwargs = {"nr_parties": nr_parties}
     CryptoPrimitiveProvider.generate_primitives(

--- a/tests/sympc/tensor/mpc_tensor_test.py
+++ b/tests/sympc/tensor/mpc_tensor_test.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from sympc.session import Session
+from sympc.session import SessionManager
 from sympc.tensor import MPCTensor
 from sympc.tensor import ShareTensor
 
@@ -24,7 +25,7 @@ def test_mpc_tensor_exception(get_clients) -> None:
 def test_reconstruct(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     a_rand = 3
     a = ShareTensor(data=a_rand, encoder_precision=0)
@@ -43,8 +44,8 @@ def test_op_mpc_different_sessions(get_clients) -> None:
     clients = get_clients(2)
     session_one = Session(parties=clients)
     session_two = Session(parties=clients)
-    Session.setup_mpc(session_one)
-    Session.setup_mpc(session_two)
+    SessionManager.setup_mpc(session_one)
+    SessionManager.setup_mpc(session_two)
 
     x = MPCTensor(secret=torch.Tensor([1, -2]), session=session_one)
     y = MPCTensor(secret=torch.Tensor([1, -2]), session=session_two)
@@ -56,7 +57,7 @@ def test_op_mpc_different_sessions(get_clients) -> None:
 def test_remote_mpc_no_shape(get_clients) -> None:
     alice_client, bob_client = get_clients(2)
     session = Session(parties=[alice_client, bob_client])
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     x_remote = alice_client.torch.Tensor([1, -2, 0.3])
 
@@ -67,7 +68,7 @@ def test_remote_mpc_no_shape(get_clients) -> None:
 def test_remote_mpc_with_shape(get_clients) -> None:
     alice_client, bob_client = get_clients(2)
     session = Session(parties=[alice_client, bob_client])
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     x_remote = alice_client.torch.Tensor([1, -2, 0.3])
     x = MPCTensor(secret=x_remote, shape=(1, 3), session=session)
@@ -79,7 +80,7 @@ def test_remote_mpc_with_shape(get_clients) -> None:
 def test_remote_not_tensor(get_clients) -> None:
     alice_client, bob_client = get_clients(2)
     session = Session(parties=[alice_client, bob_client])
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     x_remote_int = bob_client.python.Int(5)
     x = MPCTensor(secret=x_remote_int, shape=(1,), session=session)
@@ -97,7 +98,7 @@ def test_remote_not_tensor(get_clients) -> None:
 def test_local_secret_not_tensor(get_clients) -> None:
     alice_client, bob_client = get_clients(2)
     session = Session(parties=[alice_client, bob_client])
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     x_int = 5
     x = MPCTensor(secret=x_int, session=session)
@@ -117,7 +118,7 @@ def test_local_secret_not_tensor(get_clients) -> None:
 def test_ops_mpc_mpc(get_clients, nr_clients, op_str) -> None:
     clients = get_clients(nr_clients)
     session = Session(parties=clients)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     op = getattr(operator, op_str)
 
@@ -136,7 +137,7 @@ def test_ops_mpc_mpc(get_clients, nr_clients, op_str) -> None:
 def test_ops_mpc_public(get_clients, nr_clients, op_str) -> None:
     clients = get_clients(nr_clients)
     session = Session(parties=clients)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     x_secret = torch.Tensor([[0.125, -1.25], [-4.25, 4]])
 
@@ -157,7 +158,7 @@ def test_ops_mpc_public(get_clients, nr_clients, op_str) -> None:
 def test_ops_public_mpc(get_clients, nr_clients, op_str) -> None:
     clients = get_clients(nr_clients)
     session = Session(parties=clients)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     op = getattr(operator, op_str)
 
@@ -176,7 +177,7 @@ def test_ops_public_mpc(get_clients, nr_clients, op_str) -> None:
 def test_ops_integer(get_clients, nr_clients, op_str) -> None:
     clients = get_clients(nr_clients)
     session = Session(parties=clients)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     op = getattr(operator, op_str)
 
@@ -194,7 +195,7 @@ def test_ops_integer(get_clients, nr_clients, op_str) -> None:
 def test_mpc_print(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     x_secret = torch.Tensor([5.0])
 
@@ -238,7 +239,7 @@ def test_generate_shares() -> None:
 def test_generate_shares_session(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)
-    Session.setup_mpc(session)
+    SessionManager.setup_mpc(session)
 
     x_secret = torch.Tensor([5.0])
     x_share = ShareTensor(data=x_secret, session=session)


### PR DESCRIPTION
## Description

As mentioned in https://github.com/OpenMined/SyMPC/issues/36, this PR splits the `Session` class into `Session` and `SessionManager`.

Tests are included in this PR (instead of #41).

---

Closes: #36 
Closes: #39 

## Affected Dependencies
No.

## How has this been tested?
Local tests.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
