### PR TITLE
Simplify generate shares method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,9 @@ repos:
     hooks:
     -   id: bandit
         args: ['--exclude', 'tests']
+
+-   repo: https://github.com/myint/docformatter
+    rev: v1.3.1
+    hooks:
+    -   id: docformatter
+        args: [--in-place]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@
 #
 torch>=1.6
 torchcsprng
-git+git://github.com/OpenMined/PySyft/tree/sympc-dev@sympc-dev#egg=syft
+git+git://github.com/OpenMined/PySyft@0.4#egg=syft

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@
 #
 torch>=1.6
 torchcsprng
-git+git://github.com/OpenMined/PySyft@0.4#egg=syft

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,3 +7,4 @@ isort==5.6.4
 mypy==0.790
 pep8-naming==0.11.1
 pytest-cov==2.10.1
+git+git://github.com/OpenMined/PySyft.git@0.4#egg=syft

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,3 @@ isort==5.6.4
 mypy==0.790
 pep8-naming==0.11.1
 pytest-cov==2.10.1
-git+git://github.com/OpenMined/PySyft.git@sympc-dev#egg=syft

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -193,8 +193,9 @@ class MPCTensor:
         tensor_type: Optional[torch.dtype] = None,
         **kwargs,
     ) -> List[ShareTensor]:
-        """
-        Given a secret, split it into a number of shares such that each party would get one
+        """Given a secret, split it into a number of shares such that each
+        party would get one.
+
         Args:
             secret (Union[ShareTensor, torch.Tensor, float, int]): secret to split
             nr_parties (int): number of parties to split the scret
@@ -219,8 +220,6 @@ class MPCTensor:
                 | Data: tensor([14933283.]), [ShareTensor]
                 | [FixedPointEncoder]: precision: 4, base: 3
                 | Data: tensor([-14933121.])]
-
-
         """
 
         if not isinstance(secret, (ShareTensor, torch.Tensor, float, int)):

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -1,6 +1,4 @@
-"""
-Class used to have orchestrate the computation on shared values
-"""
+"""Class used to have orchestrate the computation on shared values."""
 
 # stdlib
 from functools import lru_cache
@@ -11,6 +9,7 @@ from typing import Tuple
 from typing import Union
 
 # third party
+from syft.core.node.common.client import Client
 import torch
 import torchcsprng as csprng  # type: ignore
 
@@ -23,9 +22,8 @@ from sympc.utils import parallel_execution
 
 
 class MPCTensor:
-    """
-    This class is used by an orchestrator that wants to do computation
-    on data it does not see.
+    """This class is used by an orchestrator that wants to do computation on
+    data it does not see.
 
     Arguments:
         session (Session): the session
@@ -55,8 +53,9 @@ class MPCTensor:
         shape: Optional[Union[torch.Size, List[int], Tuple[int, ...]]] = None,
         shares: Optional[List[ShareTensor]] = None,
     ) -> None:
-        """Initializer for the MPCTensor (ShareTensorControlCenter
-        It can be used in two ways:
+        """Initializer for the MPCTensor (ShareTensorControlCenter It can be
+        used in two ways:
+
         - secret is known by the orchestrator
         - secret is not known by the orchestrator (PRZS is employed)
         """
@@ -72,10 +71,9 @@ class MPCTensor:
             raise ValueError("setup_mpc was not called on the session")
 
         if secret is not None:
-            """In the case the secret is hold by a remote party then we use the PRZS
-            to generate the shares and then the pointer tensor is added to share specific
-            to the holder of the secret
-            """
+            """In the case the secret is hold by a remote party then we use the
+            PRZS to generate the shares and then the pointer tensor is added to
+            share specific to the holder of the secret."""
             secret, self.shape, is_remote_secret = MPCTensor.sanity_checks(
                 secret, shape, self.session
             )
@@ -103,7 +101,16 @@ class MPCTensor:
         self.share_ptrs = shares
 
     @staticmethod
-    def distribute_shares(shares, parties):
+    def distribute_shares(shares: List[ShareTensor], parties: List[Client]):
+        """Distribute a list of shares.
+
+        Args:
+            shares (List[ShareTensor): list of shares to distribute.
+            parties (List[Client]): list to parties to distribute.
+
+        Returns:
+            List of ShareTensorPointers.
+        """
         share_ptrs = []
         for share, party in zip(shares, parties):
             share_ptrs.append(share.send(party))
@@ -123,9 +130,14 @@ class MPCTensor:
         """Sanity check to validate that a new instance for MPCTensor can be
         created.
 
-        :return: tuple representing the ShareTensor, the shape, if the secret
-             is remote or local
-        :rtype: tuple representing the ShareTensor (it
+        Args:
+            secret (Union[ShareTensor, torch.Tensor, float, int]): secret to check
+            shape (Optional[Union[torch.Size, List[int], Tuple[int, ...]]]): shape of the secret.
+                Mandatory if secret is at another party.
+            session (Session): session
+
+        Returns:
+            Tuple representing the ShareTensor, the shape, boolean if the secret is remote or local.
         """
         is_remote_secret: bool = False
 
@@ -152,10 +164,15 @@ class MPCTensor:
     def generate_przs(
         shape: Union[torch.Size, List[int], Tuple[int, ...]], session: Session
     ) -> List[ShareTensor]:
-        """Generate Pseudo-Random-Zero Shares at the parties involved in the computation
+        """Generate Pseudo-Random-Zero Shares at the parties involved in the
+        computation.
 
-        :return: list of ShareTensor
-        :rtype: list of PRZS
+        Args:
+            shape (Union[torch.Size, List[int], Tuple[int, ...]]): shape of the tensor.
+            session: session.
+
+        Returns:
+            List[ShareTensor]. List of Pseudo-Random-Zero Shares
         """
 
         shape = tuple(shape)
@@ -171,19 +188,49 @@ class MPCTensor:
 
     @staticmethod
     def generate_shares(
-        secret: ShareTensor,
+        secret: Union[ShareTensor, torch.Tensor, float, int],
         nr_parties: int,
         tensor_type: Optional[torch.dtype] = None,
+        **kwargs,
     ) -> List[ShareTensor]:
-        """Given a secret, split it into a number of shares such that
-        each party would get one
+        """
+        Given a secret, split it into a number of shares such that each party would get one
+        Args:
+            secret (Union[ShareTensor, torch.Tensor, float, int]): secret to split
+            nr_parties (int): number of parties to split the scret
+            tensor_type (torch.dtype, optional): tensor type. Defaults to None.
+            **kwargs: keywords arguments passed to ShareTensor
 
-        :return: list of shares
-        :rtype: list of ShareTensor
+        Returns:
+            List[ShareTensor]. List of ShareTensor
+
+        Examples:
+            >>> from sympc.tensor.mpc_tensor import MPCTensor
+            >>> MPCTensor.generate_shares(secret=2, nr_parties=2)
+            [[ShareTensor]
+                | [FixedPointEncoder]: precision: 16, base: 2
+                | Data: tensor([15511500.]), [ShareTensor]
+                | [FixedPointEncoder]: precision: 16, base: 2
+                | Data: tensor([-15380428.])]
+            >>> MPCTensor.generate_shares(secret=2, nr_parties=2,
+                encoder_base=3, encoder_precision=4)
+            [[ShareTensor]
+                | [FixedPointEncoder]: precision: 4, base: 3
+                | Data: tensor([14933283.]), [ShareTensor]
+                | [FixedPointEncoder]: precision: 4, base: 3
+                | Data: tensor([-14933121.])]
+
+
         """
 
-        if not isinstance(secret, ShareTensor):
-            raise ValueError("Secret should be a ShareTensor")
+        if not isinstance(secret, (ShareTensor, torch.Tensor, float, int)):
+            raise ValueError(
+                "Secret should be a ShareTensor, torchTensor, float or int."
+            )
+
+        # if secret is not a ShareTensor, a new instance is created
+        if isinstance(secret, (torch.Tensor, float, int)):
+            secret = ShareTensor(secret, **kwargs)
 
         shape = secret.shape
 
@@ -214,18 +261,27 @@ class MPCTensor:
     def reconstruct(
         self, decode: bool = True, get_shares: bool = False
     ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        """Request and get the shares from all the parties and reconstruct the secret.
-        Depending on the value of "decode", the secret would be decoded or not using
-        the FixedPrecision Encoder specific for the session
+        """Request and get the shares from all the parties and reconstruct the
+        secret. Depending on the value of "decode", the secret would be decoded
+        or not using the FixedPrecision Encoder specific for the session.
 
-        :return: the secret reconstructed
-        :rtype: tensor
+        Args:
+            decode (bool): True if decode using FixedPointEncoder. Defaults to True
+            get_shares (boot): True if get shares. Defaults to False.
+
+        Returns:
+            torch.Tensor. The secret reconstructed.
         """
 
         def _request_and_get(share_ptr: ShareTensor) -> ShareTensor:
             """Function used to request and get a share - Duet Setup
-            :return: the ShareTensor (local)
-            :rtype: ShareTensor
+
+            Args:
+                share_ptr (ShareTensor): a ShareTensor
+
+            Returns:
+                ShareTensor. The ShareTensor in local.
+
             """
 
             if not islocal(share_ptr):
@@ -260,55 +316,80 @@ class MPCTensor:
         return plaintext
 
     def get_shares(self):
+        """Get the shares."""
         res = self.reconstruct(get_shares=True)
         return res
 
     def add(self, y: Union["MPCTensor", torch.Tensor, float, int]) -> "MPCTensor":
         """Apply the "add" operation between "self" and "y".
 
-        :return: self + y
-        :rtype: MPCTensor
+        Args:
+            y (Union["MPCTensor", torch.Tensor, float, int]: self + y
+
+        Returns:
+            MPCTensor. Result of the operation.
         """
+
         return self.__apply_op(y, "add")
 
     def sub(self, y: Union["MPCTensor", torch.Tensor, float, int]) -> "MPCTensor":
         """Apply the "sub" operation between "self" and "y".
 
-        :return: self - y
-        :rtype: MPCTensor
+        Args:
+            y (Union["MPCTensor", torch.Tensor, float, int]: self - y
+
+        Returns:
+            MPCTensor. Result of the operation.
         """
+
         return self.__apply_op(y, "sub")
 
     def rsub(self, y: Union[torch.Tensor, float, int]) -> "MPCTensor":
         """Apply the "sub" operation between "y" and "self".
 
-        :return: y - self
-        :rtype: MPCTensor
+        Args:
+            y (Union["MPCTensor", torch.Tensor, float, int]: self - y
+
+        Returns:
+            MPCTensor. Result of the operation.
         """
+
         return self.__apply_op(y, "sub") * -1
 
     def mul(self, y: Union["MPCTensor", torch.Tensor, float, int]) -> "MPCTensor":
         """Apply the "mul" operation between "self" and "y".
 
-        :return: self * y
-        :rtype: MPCTensor
+        Args:
+            y (Union["MPCTensor", torch.Tensor, float, int]: self * y
+
+        Returns:
+            MPCTensor. Result of the operation.
         """
+
         return self.__apply_op(y, "mul")
 
     def matmul(self, y: Union["MPCTensor", torch.Tensor, float, int]) -> "MPCTensor":
         """Apply the "matmul" operation between "self" and "y".
 
-        :return: self @ y
-        :rtype: MPCTensor
+        Args:
+            y (Union["MPCTensor", torch.Tensor, float, int]: self @ y
+
+        Returns:
+            MPCTensor. Result of the operation.
         """
+
         return self.__apply_op(y, "matmul")
 
     def rmatmul(self, y: torch.Tensor) -> "MPCTensor":
-        """Apply the "matmul" operation between "y" and "self".
+        """Apply the "rmatmul" operation between "y" and "self".
 
-        :return: y @ self
-        :rtype: MPCTensor
+        Args:
+            y (Union["MPCTensor", torch.Tensor, float, int]: y @ self
+
+        Returns:
+            MPCTensor. Result of the operation.
         """
+
         op = getattr(operator, "matmul")
         shares = [op(y, share) for share in self.share_ptrs]
 
@@ -330,13 +411,16 @@ class MPCTensor:
     def div(self, y: Union["MPCTensor", torch.Tensor, float, int]) -> "MPCTensor":
         """Apply the "div" operation between "self" and "y".
 
-        :return: self / y
-        :rtype: MPCTensor
+        Args:
+            y (Union["MPCTensor", torch.Tensor, float, int]: self / y
+
+        Returns:
+            MPCTensor. Result of the operation.
         """
 
         is_private = isinstance(y, MPCTensor)
         if is_private:
-            raise ValueError("Not implemented!")
+            raise NotImplementedError("Not implemented for MPCTensor")
 
         from sympc.protocol.spdz import spdz
 
@@ -346,9 +430,14 @@ class MPCTensor:
     def __apply_private_op(self, y: "MPCTensor", op_str: str) -> "MPCTensor":
         """Apply an operation on 2 MPCTensor (secret shared values)
 
-        :return: the operation "op_str" applied on "self" and "y"
-        :rtype: MPCTensor
+        Args:
+            y (MPCTensor): tensor to apply the operation
+            op_str (str): the operation
+
+        Returns:
+            MPCTensor. The operation "op_str" applied on "self" and "y"
         """
+
         if y.session.uuid != self.session.uuid:
             raise ValueError(
                 f"Need same session {self.session.uuid} and {y.session.uuid}"
@@ -371,10 +460,15 @@ class MPCTensor:
     def __apply_public_op(
         self, y: Union[torch.Tensor, float, int], op_str: str
     ) -> "MPCTensor":
-        """Apply an operation on "self" which is a MPCTensor and a public value
+        """Apply an operation on "self" which is a MPCTensor and a public
+        value.
 
-        :return: the operation "op_str" applied on "self" and "y"
-        :rtype: MPCTensor
+        Args:
+            y (Union[torch.Tensor, float, int]): tensor to apply the operation.
+            op_str (str): the operation.
+
+        Returns:
+            MPCTensor. The operation "op_str" applied on "self" and "y"
         """
 
         op = getattr(operator, op_str)
@@ -411,12 +505,17 @@ class MPCTensor:
     def __apply_op(
         self, y: Union["MPCTensor", torch.Tensor, float, int], op_str: str
     ) -> "MPCTensor":
-        """Apply an operation on "self" which is a MPCTensor "y"
-        This function checks if "y" is private or public value
+        """Apply an operation on "self" which is a MPCTensor "y" This function
+        checks if "y" is private or public value.
 
-        :return: the operation "op_str" applied on "self" and "y"
-        :rtype: MPCTensor
+        Args:
+            y: tensor to apply the operation.
+            op_str: the operation.
+
+        Returns:
+            MPCTensor. the operation "op_str" applied on "self" and "y"
         """
+
         is_private = isinstance(y, MPCTensor)
 
         if is_private:
@@ -444,13 +543,16 @@ class MPCTensor:
         return result
 
     def __str__(self) -> str:
-        """ Return the string representation of MPCTensor """
+        """Return the string representation of MPCTensor."""
         type_name = type(self).__name__
         out = f"[{type_name}]\nShape: {self.shape}"
 
         for share in self.share_ptrs:
             out = f"{out}\n\t| {share.client} -> {share.__name__}"
         return out
+
+    def __repr__(self):
+        return self.__str__()
 
     __add__ = add
     __radd__ = add

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -222,14 +222,14 @@ class MPCTensor:
                 | Data: tensor([-14933121.])]
         """
 
-        if not isinstance(secret, (ShareTensor, torch.Tensor, float, int)):
+        if isinstance(secret, (torch.Tensor, float, int)):
+            secret = ShareTensor(secret, **kwargs)
+
+        # if secret is not a ShareTensor, a new instance is created
+        if not isinstance(secret, ShareTensor):
             raise ValueError(
                 "Secret should be a ShareTensor, torchTensor, float or int."
             )
-
-        # if secret is not a ShareTensor, a new instance is created
-        if isinstance(secret, (torch.Tensor, float, int)):
-            secret = ShareTensor(secret, **kwargs)
 
         shape = secret.shape
 

--- a/src/sympc/tensor/share_tensor.py
+++ b/src/sympc/tensor/share_tensor.py
@@ -44,7 +44,6 @@ class ShareTensor:
         "tensor",
         "session",
         "fp_encoder",
-        "data",
     }
 
     def __init__(
@@ -77,12 +76,11 @@ class ShareTensor:
         self.tensor: Optional[torch.Tensor] = None
 
         if data is not None:
-            self.data = data
             tensor_type = self.session.tensor_type
-            self.tensor = self._encode().type(tensor_type)
+            self.tensor = self._encode(data).type(tensor_type)
 
-    def _encode(self):
-        return self.fp_encoder.encode(self.data)
+    def _encode(self, data):
+        return self.fp_encoder.encode(data)
 
     def decode(self):
         return self._decode()

--- a/src/sympc/tensor/share_tensor.py
+++ b/src/sympc/tensor/share_tensor.py
@@ -1,6 +1,4 @@
-"""
-Class used to represent a share owned by a party
-"""
+"""Class used to represent a share owned by a party."""
 
 # stdlib
 import operator
@@ -16,9 +14,8 @@ from sympc.session import Session
 
 
 class ShareTensor:
-    """
-    This class represents 1 share that a party holds when doing
-    secret sharing
+    """This class represents 1 share that a party holds when doing secret
+    sharing.
 
     Arguments:
         data (Optional[Any]): the share a party holds
@@ -47,6 +44,7 @@ class ShareTensor:
         "tensor",
         "session",
         "fp_encoder",
+        "data",
     }
 
     def __init__(
@@ -57,7 +55,7 @@ class ShareTensor:
         encoder_precision: int = 16,
         ring_size: int = 2 ** 64,
     ) -> None:
-        """ Initializer for the ShareTensor """
+        """Initializer for the ShareTensor."""
 
         if session is None:
             self.session = Session(
@@ -79,15 +77,24 @@ class ShareTensor:
         self.tensor: Optional[torch.Tensor] = None
 
         if data is not None:
+            self.data = data
             tensor_type = self.session.tensor_type
-            self.tensor = self.fp_encoder.encode(data).type(tensor_type)
+            self.tensor = self._encode().type(tensor_type)
+
+    def _encode(self):
+        return self.fp_encoder.encode(self.data)
+
+    def decode(self):
+        return self._decode()
+
+    def _decode(self):
+        return self.fp_encoder.decode(self.tensor.type(torch.LongTensor))
 
     @staticmethod
     def sanity_checks(
         x: "ShareTensor", y: Union[int, float, torch.Tensor, "ShareTensor"], op_str: str
     ) -> "ShareTensor":
-        """
-        Check the type of "y" and convert it to a share if necessary
+        """Check the type of "y" and convert it to a share if necessary.
 
         :return: the y value
         :rtype: ShareTensor, int or Integer type Tensor
@@ -100,7 +107,7 @@ class ShareTensor:
     def apply_function(
         self, y: Union["ShareTensor", torch.Tensor, int, float], op_str: str
     ) -> "ShareTensor":
-        """Apply a given operation
+        """Apply a given operation.
 
         :return: the result of applying "op_str" on "self" and y
         :rtype: ShareTensor
@@ -117,7 +124,7 @@ class ShareTensor:
         return res
 
     def add(self, y: Union[int, float, torch.Tensor, "ShareTensor"]) -> "ShareTensor":
-        """Apply the "add" operation between "self" and "y"
+        """Apply the "add" operation between "self" and "y".
 
         :return: self + y
         :rtype: ShareTensor
@@ -127,7 +134,7 @@ class ShareTensor:
         return res
 
     def sub(self, y: Union[int, float, torch.Tensor, "ShareTensor"]) -> "ShareTensor":
-        """Apply the "sub" operation between "self" and "y"
+        """Apply the "sub" operation between "self" and "y".
 
         :return: self - y
         :rtype: ShareTensor
@@ -137,7 +144,7 @@ class ShareTensor:
         return res
 
     def rsub(self, y: Union[int, float, torch.Tensor, "ShareTensor"]) -> "ShareTensor":
-        """Apply the "sub" operation between "y" and "self"
+        """Apply the "sub" operation between "y" and "self".
 
         :return: y - self
         :rtype: ShareTensor
@@ -147,7 +154,7 @@ class ShareTensor:
         return res
 
     def mul(self, y: Union[int, float, torch.Tensor, "ShareTensor"]) -> "ShareTensor":
-        """Apply the "mul" operation between "self" and "y"
+        """Apply the "mul" operation between "self" and "y".
 
         :return: self * y
         :rtype: ShareTensor
@@ -166,7 +173,7 @@ class ShareTensor:
     def matmul(
         self, y: Union[int, float, torch.Tensor, "ShareTensor"]
     ) -> "ShareTensor":
-        """Apply the "matmul" operation between "self" and "y"
+        """Apply the "matmul" operation between "self" and "y".
 
         :return: self @ y
         :rtype: ShareTensor
@@ -183,7 +190,7 @@ class ShareTensor:
         return res
 
     def rmatmul(self, y: torch.Tensor) -> "ShareTensor":
-        """Apply the reversed "matmul" operation between "self" and "y"
+        """Apply the reversed "matmul" operation between "self" and "y".
 
         :return: y @ self
         :rtype: ShareTensor
@@ -192,8 +199,8 @@ class ShareTensor:
         return y.matmul(self)
 
     def div(self, y: Union[int, float, torch.Tensor, "ShareTensor"]) -> "ShareTensor":
-        """Apply the "div" operation between "self" and "y".
-        Currently, NotImplemented
+        """Apply the "div" operation between "self" and "y". Currently,
+        NotImplemented.
 
         :return: self / y
         :rtype: ShareTensor
@@ -207,9 +214,9 @@ class ShareTensor:
         return res
 
     def __getattr__(self, attr_name: str) -> Any:
-        """Get the attribute from the ShareTensor.
-        If the attribute is not found at the ShareTensor level, the it would
-        look for in the the "tensor"
+        """Get the attribute from the ShareTensor. If the attribute is not
+        found at the ShareTensor level, the it would look for in the the
+        "tensor".
 
         :return: the attribute value
         :rtype: Anything
@@ -220,7 +227,7 @@ class ShareTensor:
         return getattr(tensor, attr_name)
 
     def __gt__(self, y: Union["ShareTensor", torch.Tensor, int]) -> bool:
-        """Check if "self" is bigger than "y"
+        """Check if "self" is bigger than "y".
 
         :return: self > y
         :rtype: bool
@@ -230,7 +237,7 @@ class ShareTensor:
         return res
 
     def __lt__(self, y: Union["ShareTensor", torch.Tensor, int]) -> bool:
-        """Check if "self" is less than "y"
+        """Check if "self" is less than "y".
 
         :return: self < y
         :rtype: bool
@@ -241,7 +248,7 @@ class ShareTensor:
         return res
 
     def __str__(self) -> str:
-        """ Return the string representation of ShareTensor """
+        """Return the string representation of ShareTensor."""
         type_name = type(self).__name__
         out = f"[{type_name}]"
         out = f"{out}\n\t| {self.fp_encoder}"
@@ -249,10 +256,12 @@ class ShareTensor:
 
         return out
 
+    def __repr__(self):
+        return self.__str__()
+
     def __eq__(self, other: Any) -> bool:
-        """
-        Check if "self" is equal with another object given a set of attributes
-        to compare.
+        """Check if "self" is equal with another object given a set of
+        attributes to compare.
 
         :return: if self and other are equal
         :rtype: bool

--- a/tests/sympc/tensor/mpc_tensor_test.py
+++ b/tests/sympc/tensor/mpc_tensor_test.py
@@ -210,7 +210,7 @@ def test_mpc_print(get_clients) -> None:
     assert x.__str__() == x.__str__()
 
 
-def test_generate_shares(get_clients) -> None:
+def test_generate_shares() -> None:
 
     precision = 12
     base = 4
@@ -246,4 +246,4 @@ def test_generate_shares_session(get_clients) -> None:
     shares_from_share_tensor = MPCTensor.generate_shares(x_share, 2)
     shares_from_secret = MPCTensor.generate_shares(x_secret, 2, session=session)
 
-    assert sum(shares_from_share_tensor).tensor == sum(shares_from_secret).tensor
+    assert sum(shares_from_share_tensor) == sum(shares_from_secret)

--- a/tests/sympc/tensor/mpc_tensor_test.py
+++ b/tests/sympc/tensor/mpc_tensor_test.py
@@ -7,6 +7,7 @@ import torch
 
 from sympc.session import Session
 from sympc.tensor import MPCTensor
+from sympc.tensor import ShareTensor
 
 
 def test_mpc_tensor_exception(get_clients) -> None:
@@ -24,6 +25,12 @@ def test_reconstruct(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)
     Session.setup_mpc(session)
+
+    a_rand = 3
+    a = ShareTensor(data=a_rand, encoder_precision=0)
+    a_shares = MPCTensor.generate_shares(a, 2, torch.long)
+
+    a_shares_copy = MPCTensor.generate_shares(a_rand, 2, torch.long)
 
     x_secret = torch.Tensor([1, -2, 3.0907, -4.870])
     x = MPCTensor(secret=x_secret, session=session)
@@ -200,3 +207,43 @@ def test_mpc_print(get_clients) -> None:
     expected = f"{expected} <VirtualMachineClient: P_1 Client> -> ShareTensorPointer"
 
     assert expected == x.__str__()
+    assert x.__str__() == x.__str__()
+
+
+def test_generate_shares(get_clients) -> None:
+
+    precision = 12
+    base = 4
+
+    x_secret = torch.Tensor([5.0])
+
+    # test with default values
+    x_share = ShareTensor(data=x_secret)
+
+    shares_from_share_tensor = MPCTensor.generate_shares(x_share, 2)
+    shares_from_secret = MPCTensor.generate_shares(x_secret, 2)
+
+    assert sum(shares_from_share_tensor).tensor == sum(shares_from_secret).tensor
+
+    x_share = ShareTensor(data=x_secret, encoder_precision=precision, encoder_base=base)
+
+    shares_from_share_tensor = MPCTensor.generate_shares(x_share, 2)
+    shares_from_secret = MPCTensor.generate_shares(
+        x_secret, 2, encoder_precision=precision, encoder_base=base
+    )
+
+    assert sum(shares_from_share_tensor).tensor == sum(shares_from_secret).tensor
+
+
+def test_generate_shares_session(get_clients) -> None:
+    clients = get_clients(2)
+    session = Session(parties=clients)
+    Session.setup_mpc(session)
+
+    x_secret = torch.Tensor([5.0])
+    x_share = ShareTensor(data=x_secret, session=session)
+
+    shares_from_share_tensor = MPCTensor.generate_shares(x_share, 2)
+    shares_from_secret = MPCTensor.generate_shares(x_secret, 2, session=session)
+
+    assert sum(shares_from_share_tensor).tensor == sum(shares_from_secret).tensor

--- a/tests/sympc/tensor/share_tensor_test.py
+++ b/tests/sympc/tensor/share_tensor_test.py
@@ -150,3 +150,24 @@ def test_share_print() -> None:
     expected = f"{expected}\n\t| Data: {encoded_x}"
 
     assert expected == x_share.__str__()
+
+
+def test_share_repr() -> None:
+
+    x = torch.Tensor([5.0])
+    x_share = ShareTensor(data=x)
+
+    encoded_x = x_share.fp_encoder.encode(x)
+
+    expected = f"[ShareTensor]\n\t| {x_share.fp_encoder}"
+    expected = f"{expected}\n\t| Data: {encoded_x}"
+
+    assert expected == x_share.__str__() == x_share.__repr__()
+
+
+def test_share_decode() -> None:
+
+    x = torch.Tensor([5.0])
+    x_share = ShareTensor(data=x)
+
+    assert x == x_share.decode()


### PR DESCRIPTION
## Description
Extend `MPCTensor.generate_shares` in order to simplify the API.

Now there are two ways of call this method:
 1. From ShareTensor
```python
secret = torch.Tensor([5])
a = ShareTensor(data=secret)
MPCTensor.generate_shares(secret = a, nr_parties = 2)
```
2. Directly from a secret (torch.Tensor)
```python
secret = torch.Tensor([5])

MPCTensor.generate_shares(secret = secret, nr_parties = 2)  # with default values
MPCTensor.generate_shares(secret = secret, nr_parties = 2, encoder_precision=16, base_precision=2)  # with extra kwargs 
```

Other minor modifications:
* Add method `.decode()` to recover the original value from ShareTensor
* Convert to `Google` docstring for the file `mpc_tensor.py`
* Add `__repr__` method to `ShareTensor` and `MPCTensor`
* Add `docstringformatter` to `pre-commit` to help with the format of the documentation.

This PR closes #46 and partially the issue #28 

## Affected Dependencies
I have upgraded to `syft==0.4`

## How has this been tested?
I have included additional test.


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
