### PR TITLE
Remove populate_crypto_store method

### DIFF
--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -142,11 +142,6 @@ class Session:
         self.min_value = -(ring_size) // 2
         self.max_value = (ring_size - 1) // 2
 
-    def populate_crypto_store(
-        self, op_str: str, primitives: Any, *args: List[Any], **kwargs: Dict[Any, Any]
-    ) -> None:
-        self.crypto_store.populate_store(op_str, primitives, *args, **kwargs)
-
     def przs_generate_random_share(
         self, shape: Union[tuple, torch.Size], generators: List[torch.Generator]
     ) -> Any:

--- a/src/sympc/store/crypto_primitive_provider.py
+++ b/src/sympc/store/crypto_primitive_provider.py
@@ -8,7 +8,8 @@ from sympc.session import Session
 
 
 class CryptoPrimitiveProvider:
-    """A trusted third party should use this class to generate crypto primitives """
+    """A trusted third party should use this class to generate crypto
+    primitives."""
 
     _func_providers: Dict[str, Callable] = {}
 
@@ -23,10 +24,9 @@ class CryptoPrimitiveProvider:
         g_kwargs: Dict[str, Any] = {},
         p_kwargs: Dict[str, Any] = {},
     ) -> List[Any]:
-        """
-        Generate "op_str" primitives.
-        The "g_kwargs" (generate kwargs) are passed to the registered generator function
-        The "p_kwargs" (populate kwargs) are passed to the registered populate function
+        """Generate "op_str" primitives. The "g_kwargs" (generate kwargs) are
+        passed to the registered generator function The "p_kwargs" (populate
+        kwargs) are passed to the registered populate function.
 
         :return: list of primitives
         :rtype: list of Any Type
@@ -58,10 +58,8 @@ class CryptoPrimitiveProvider:
         primitives = list(zip(*map(lambda x: zip(*x), primitives_sequential)))
 
         if p_kwargs is not None:
-            """
-            Do not transfer the primitives if there is not
-            specified a values for populate kwargs
-            """
+            """Do not transfer the primitives if there is not specified a
+            values for populate kwargs."""
             CryptoPrimitiveProvider._transfer_primitives_to_parties(
                 op_str, primitives, sessions, p_kwargs
             )
@@ -89,7 +87,9 @@ class CryptoPrimitiveProvider:
             )
 
         for primitives_party, session in zip(primitives, sessions):
-            session.populate_crypto_store(op_str, list(primitives_party), **p_kwargs)
+            session.crypto_store.populate_store(
+                op_str, list(primitives_party), **p_kwargs
+            )
 
     @staticmethod
     def get_state() -> None:


### PR DESCRIPTION
## Description

This PR removes the `populate_crypto_store` method from the code-base. For more info see this: #61 

Closes: #61 

## Affected Dependencies
No.

## How has this been tested?
Locally.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
