### PR TITLE
Add metaclass to forward tensor specific methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: requirements-txt-fixer # Sort entries in requirements.txt
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.7.0
+    rev: 5.8.0
     hooks:
       - id: isort
 
@@ -31,7 +31,7 @@ repos:
         additional_dependencies: [black==20.8b1]
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
       - id: flake8
 
@@ -44,7 +44,7 @@ repos:
 
 
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 5.1.1  # pick a git hash / tag to point to
+    rev: 6.0.0  # pick a git hash / tag to point to
     hooks:
       - id: pydocstyle
         args:
@@ -52,11 +52,7 @@ repos:
         exclude: ^tests/
 
   - repo: https://github.com/terrencepreilly/darglint
-    rev: master
+    rev: v1.8.0
     hooks:
       - id: darglint
         exclude: ^tests/
-
-
-
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -135,7 +135,7 @@ ignore_comments = False
 honor_noqa = True
 
 [darglint]
-style=google # Default style is Google but we opt to be explicit about it
+docstring_style=GOOGLE
 
 [mypy]
 python_version = 3.9

--- a/src/sympc/tensor/__init__.py
+++ b/src/sympc/tensor/__init__.py
@@ -1,5 +1,6 @@
 """Custom MPC Tensors."""
 
+
 from .share_tensor import ShareTensor  # isort:skip
 from .mpc_tensor import METHODS_TO_ADD
 from .mpc_tensor import MPCTensor

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -746,7 +746,7 @@ class MPCTensor(metaclass=SyMPCTensor):
         """Hook a framework method.
 
         Ex:
-         * if we call "numel" we want to forward it only to one share an return
+         * if we call "numel" we want to forward it only to one share and return
         the result (without wrapping it in an MPCShare)
          * if we call "unsqueeze" we want to call it on all the underlying shares
         and we want to wrap those shares in a new MPCTensor

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -30,8 +30,7 @@ METHODS_FORWARD_ALL_SHARES = {}
 
 
 class MPCTensor(metaclass=SyMPCTensor):
-    """This class is used by an orchestrator that wants to do computation on
-    data it does not see.
+    """Used by the orchestrator to compute on the shares.
 
     Arguments:
         session (Session): the session
@@ -67,7 +66,7 @@ class MPCTensor(metaclass=SyMPCTensor):
         shape: Optional[Union[torch.Size, List[int], Tuple[int, ...]]] = None,
         shares: Optional[List[ShareTensor]] = None,
     ) -> None:
-        """Initializer for the MPCTensor. It can be used in two ways:
+        """Initializer for the MPCTensor. It can be used in two ways.
 
         ShareTensorControlCenter can be used in two ways:
         - secret is known by the orchestrator.
@@ -703,8 +702,7 @@ class MPCTensor(metaclass=SyMPCTensor):
 
     @staticmethod
     def hook_property(property_name: str) -> Any:
-        """Hook a framework property (only getter) such that we know how to
-        treat it given that we call it.
+        """Hook a framework property (only getter).
 
         Ex:
          * if we call "shape" we want to call it on the underlying share
@@ -713,7 +711,7 @@ class MPCTensor(metaclass=SyMPCTensor):
         and wrap the result in an MPCTensor
 
         Args:
-            property_nam (str): property to hook
+            property_name (str): property to hook
 
         Returns:
             A hooked property
@@ -743,8 +741,7 @@ class MPCTensor(metaclass=SyMPCTensor):
 
     @staticmethod
     def hook_method(method_name: str) -> Callable[..., Any]:
-        """Hook a framework method such that we know how to treat it given that
-        we call it.
+        """Hook a framework method.
 
         Ex:
          * if we call "numel" we want to forward it only to one share an return
@@ -753,7 +750,7 @@ class MPCTensor(metaclass=SyMPCTensor):
         and we want to wrap those shares in a new MPCTensor
 
         Args:
-            method_name (name): method to hook
+            method_name (str): method to hook
 
         Returns:
             A hooked method

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -87,9 +87,11 @@ class MPCTensor(metaclass=SyMPCTensor):
         Raises:
             ValueError: If session is not provided as argument or in the ShareTensor.
         """
-        if session is None and secret.session is None:
+        if session is None and (
+            not isinstance(secret, ShareTensor) or secret.session is None
+        ):
             raise ValueError(
-                "Need to provide a session, as argument or in the ShareTensor"
+                "Need to provide a session, as argument or the secret should be a ShareTensor"
             )
 
         self.session = session if session is not None else secret.session

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -1,4 +1,4 @@
-"""Class used to have orchestrate the computation on shared values."""
+"""Class used to orchestrate the computation on shared values."""
 
 # stdlib
 from functools import lru_cache
@@ -22,9 +22,27 @@ from sympc.utils import islocal
 from sympc.utils import ispointer
 from sympc.utils import parallel_execution
 
+from .tensor import SyMPCTensor
 
-class MPCTensor:
-    """MultiPartyComputationTensor.
+PROPERTIES_FORWARD_ALL_SHARES = {"T"}
+METHODS_FORWARD_ALL_SHARES = {}
+
+
+class MPCTensor(metaclass=SyMPCTensor):
+    """This class is used by an orchestrator that wants to do computation on
+    data it does not see.
+
+    Arguments:
+        session (Session): the session
+        secret (Optional[Union[torch.Tensor, float, int]): in case the secret is
+            known by the orchestrator it is split in shares and given to multiple
+            parties
+        shape (Optional[Union[torch.Size, tuple]): the shape of the secret in case
+            the secret is not known by the orchestrator
+            this is needed when a multiplication is needed between two secret values
+            (need the shapes to be able to generate random elements in the proper way)
+        shares (Optional[List[ShareTensor]]): in case the shares are already at the
+             parties involved in the computation
 
     This class is used by an orchestrator that wants to do computation on
     data it does not see.
@@ -37,6 +55,10 @@ class MPCTensor:
 
     __slots__ = {"share_ptrs", "session", "shape"}
 
+    # Used by the SyMPCTensor metaclass
+    METHODS_FORWARD = {"numel"}
+    PROPERTIES_FORWARD = {"T"}
+
     def __init__(
         self,
         session: Optional[Session] = None,
@@ -44,7 +66,7 @@ class MPCTensor:
         shape: Optional[Union[torch.Size, List[int], Tuple[int, ...]]] = None,
         shares: Optional[List[ShareTensor]] = None,
     ) -> None:
-        """Initializer for the MPCTensor.
+        """Initializer for the MPCTensor. It can be used in two ways:
 
         ShareTensorControlCenter can be used in two ways:
         - secret is known by the orchestrator.
@@ -678,24 +700,57 @@ class MPCTensor:
         else:
             return value
 
-    def numel(self) -> int:
-        """Number of elements.
+    @staticmethod
+    def hook_property(property_name: str):
+        def property_all_share_getter(_self: "MPCTensor") -> "MPCTensor":
+            shares = []
 
-        Returns:
-            int: Number of elements.
-        """
-        return self.share_ptrs[0].numel()
+            for share in _self.share_ptrs:
+                prop = getattr(share, property_name)
+                shares.append(prop)
 
-    @property
-    def T(self) -> "MPCTensor":
-        """Transpose.
+            new_shape = getattr(torch.empty(_self.shape), property_name).shape
+            res = MPCTensor(shares=shares, shape=new_shape, session=_self.session)
+            return res
 
-        Returns:
-            MPCTensor: Transpose Tensor.
-        """
-        shares = [share.T for share in self.share_ptrs]
-        res = MPCTensor(shares=shares, session=self.session)
-        res.shape = torch.empty(self.shape).T.shape
+        def property_share_getter(_self: "MPCTensor") -> Any:
+            prop = getattr(_self.share_ptrs[0], property_name)
+            return prop
+
+        if property_name in PROPERTIES_FORWARD_ALL_SHARES:
+            res = property(property_all_share_getter, None)
+        else:
+            res = property(property_share_getter, None)
+
+        return res
+
+    @staticmethod
+    def hook_method(method_name: str):
+        def method_all_shares(
+            _self: "MPCTensor", *args: List[Any], **kwargs: Dict[Any, Any]
+        ) -> Any:
+            shares = []
+
+            for share in _self.share_ptrs:
+                method = getattr(share, method_name)
+                shares.append(method(*args, **kwargs))
+
+            new_shape = getattr(torch.empty(_self.shape), method_name).shape
+            res = MPCTensor(shares=shares, shape=new_shape, session=_self.session)
+            return res
+
+        def method_share(
+            _self: "MPCTensor", *args: List[Any], **kwargs: Dict[Any, Any]
+        ) -> Any:
+            method = getattr(_self.share_ptrs[0], method_name)
+            res = method(*args, **kwargs)
+            return res
+
+        if method_name in METHODS_FORWARD_ALL_SHARES:
+            res = method_all_shares
+        else:
+            res = method_share
+
         return res
 
     def unsqueeze(self, *args, **kwargs) -> "MPCTensor":

--- a/src/sympc/tensor/share_tensor.py
+++ b/src/sympc/tensor/share_tensor.py
@@ -22,8 +22,7 @@ PROPERTIES_NEW_SHARE_TENSOR: Set[str] = {"T"}
 METHODS_NEW_SHARE_TENSOR: Set[str] = {"unsqueeze", "view"}
 
 class ShareTensor(metaclass=SyMPCTensor):
-    """This class represents 1 share that a party holds when doing secret
-    sharing.
+    """Single Share representation.
 
     Arguments:
         data (Optional[Any]): the share a party holds
@@ -371,8 +370,7 @@ class ShareTensor(metaclass=SyMPCTensor):
 
     @staticmethod
     def hook_property(property_name: str) -> Any:
-        """Hook a framework property (only getter) such that we know how to
-        treat it given that we call it.
+        """Hook a framework property (only getter).
 
         Ex:
          * if we call "shape" we want to call it on the underlying tensor
@@ -381,7 +379,7 @@ class ShareTensor(metaclass=SyMPCTensor):
         but we want to wrap it in the same tensor type
 
         Args:
-            property_nam (str): property to hook
+            property_name (str): property to hook
 
         Returns:
             A hooked property
@@ -406,8 +404,7 @@ class ShareTensor(metaclass=SyMPCTensor):
 
     @staticmethod
     def hook_method(method_name: str) -> Callable[..., Any]:
-        """Hook a framework method such that we know how to treat it given that
-        we call it.
+        """Hook a framework method such that we know how to treat it given that we call it.
 
         Ex:
          * if we call "numel" we want to call it on the underlying tensor
@@ -416,7 +413,7 @@ class ShareTensor(metaclass=SyMPCTensor):
         but we want to wrap it in the same tensor type
 
         Args:
-            method_name (name): method to hook
+            method_name (str): method to hook
 
         Returns:
             A hooked method

--- a/src/sympc/tensor/share_tensor.py
+++ b/src/sympc/tensor/share_tensor.py
@@ -21,6 +21,7 @@ from .tensor import SyMPCTensor
 PROPERTIES_NEW_SHARE_TENSOR: Set[str] = {"T"}
 METHODS_NEW_SHARE_TENSOR: Set[str] = {"unsqueeze", "view"}
 
+
 class ShareTensor(metaclass=SyMPCTensor):
     """Single Share representation.
 

--- a/src/sympc/tensor/tensor.py
+++ b/src/sympc/tensor/tensor.py
@@ -11,23 +11,25 @@ from typing import cast
 
 
 class SyMPCTensor(type):
+    """Metaclass for the MPCTensor and ShareTensors."""
+
+    @classmethod
     def __new__(
-        cls: Type["SyMPCTensor"],
-        name: str,
-        bases: Tuple[Any],
-        dic: Dict[str, Any],
+        cls: Type["SyMPCTensor"], name: str, bases: Tuple[Any], dic: Dict[str, Any]
     ) -> "SyMPCTensor":
         """Add new methods and properties to the defined tensor classes.
 
         Args:
-            cls (Type[SyMPCTensor]): type of the class
             name (str): name of the class which has SyMPCTensor metaclass
             bases (Tuple[Any]): classes from which our class inherits
             dic (Dict[str, Any]): attributes of the class
+
         Returns:
             The new class with added methods
-        """
 
+        Raises:
+            ValueError: the method we try to add is already defined in the class
+        """
         res = super().__new__(cls, name, bases, dic)
 
         forward_methods = getattr(res, "METHODS_FORWARD")

--- a/src/sympc/tensor/tensor.py
+++ b/src/sympc/tensor/tensor.py
@@ -1,5 +1,7 @@
-"""The Metaclass used for the Tensors from SyMPC We use this such that we can
-have a forward mechanism."""
+"""The Metaclass used for the Tensors from SyMPC.
+
+We use this such that we can have a forward mechanism.
+"""
 # stdlib
 from typing import Any
 from typing import Dict
@@ -15,6 +17,16 @@ class SyMPCTensor(type):
         bases: Tuple[Any],
         dic: Dict[str, Any],
     ) -> "SyMPCTensor":
+        """Add new methods and properties to the defined tensor classes.
+
+        Args:
+            cls (Type[SyMPCTensor]): type of the class
+            name (str): name of the class which has SyMPCTensor metaclass
+            bases (Tuple[Any]): classes from which our class inherits
+            dic (Dict[str, Any]): attributes of the class
+        Returns:
+            The new class with added methods
+        """
 
         res = super().__new__(cls, name, bases, dic)
 

--- a/src/sympc/tensor/tensor.py
+++ b/src/sympc/tensor/tensor.py
@@ -13,7 +13,6 @@ from typing import cast
 class SyMPCTensor(type):
     """Metaclass for the MPCTensor and ShareTensors."""
 
-    @classmethod
     def __new__(
         cls: Type["SyMPCTensor"], name: str, bases: Tuple[Any], dic: Dict[str, Any]
     ) -> "SyMPCTensor":

--- a/src/sympc/tensor/tensor.py
+++ b/src/sympc/tensor/tensor.py
@@ -1,0 +1,37 @@
+"""The Metaclass used for the Tensors from SyMPC We use this such that we can
+have a forward mechanism."""
+# stdlib
+from typing import Any
+from typing import Dict
+from typing import Tuple
+from typing import Type
+from typing import cast
+
+
+class SyMPCTensor(type):
+    def __new__(
+        cls: Type["SyMPCTensor"],
+        name: str,
+        bases: Tuple[Any],
+        dic: Dict[str, Any],
+    ) -> "SyMPCTensor":
+
+        res = super().__new__(cls, name, bases, dic)
+
+        forward_methods = getattr(res, "METHODS_FORWARD")
+        hook_method = getattr(res, "hook_method")
+        for method in forward_methods:
+            if method in res.__dict__:
+                raise ValueError(f"Attribute {method} already exists in {name}")
+            setattr(res, method, hook_method(method))
+
+        forward_properties = getattr(res, "PROPERTIES_FORWARD")
+
+        hook_property = getattr(res, "hook_property")
+        for prop in forward_properties:
+            if prop in res.__dict__:
+                raise ValueError(f"Attribute {prop} already exists in {name}")
+            setattr(res, prop, hook_property(prop))
+
+        res = cast(SyMPCTensor, res)
+        return res


### PR DESCRIPTION
## Description
This metaclass it is used to forward torch tensor specific methods/properties to down the shares/tensors.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- All the tests should pass

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
