### PR TITLE
test: parametrize reciprocal

### DIFF
--- a/tests/sympc/approximations/reci_test.py
+++ b/tests/sympc/approximations/reci_test.py
@@ -7,6 +7,7 @@ from sympc.session import Session
 from sympc.session import SessionManager
 from sympc.tensor.mpc_tensor import MPCTensor
 
+
 @pytest.mark.parametrize("method", ["nr", "log"])
 def test_reciprocal(method, get_clients) -> None:
     clients = get_clients(2)

--- a/tests/sympc/approximations/reci_test.py
+++ b/tests/sympc/approximations/reci_test.py
@@ -7,8 +7,8 @@ from sympc.session import Session
 from sympc.session import SessionManager
 from sympc.tensor.mpc_tensor import MPCTensor
 
-
-def test_reciprocal(get_clients) -> None:
+@pytest.mark.parametrize("method", ["nr", "log"])
+def test_reciprocal(method, get_clients) -> None:
     clients = get_clients(2)
     session_one = Session(parties=clients)
     SessionManager.setup_mpc(session_one)
@@ -18,10 +18,7 @@ def test_reciprocal(get_clients) -> None:
     x = MPCTensor(secret=x_secret, session=session_one)
     x_secret_reciprocal = torch.reciprocal(x_secret)
 
-    x_reciprocal = reciprocal(x, method="nr")
-    assert torch.allclose(x_secret_reciprocal, x_reciprocal.reconstruct(), atol=1e-1)
-
-    x_reciprocal = reciprocal(x, method="log")
+    x_reciprocal = reciprocal(x, method=method)
     assert torch.allclose(x_secret_reciprocal, x_reciprocal.reconstruct(), atol=1e-1)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Description
Use pytest parametrize to convert the reciprocal test with two asserts, into two tests. One test for each method.
Closes #107

## How has this been tested?
- You can run `pytest tests/sympc/approximations/reci_test.py` from the root and should see something like in the image.
![image](https://user-images.githubusercontent.com/20444151/114778770-95822180-9d75-11eb-830d-85ca04ac0963.png)

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
