### PR TITLE
Solves cancelling previous jobs #102

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [published]
 
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ on:
       - "requirements_dev.txt"
       - "requirements.txt"
 
+
 jobs:
   python-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ on:
       - "requirements_dev.txt"
       - "requirements.txt"
 
-
 jobs:
   python-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -16,6 +16,7 @@ on:
       - "**.ipynb"
       - "requirements*.txt"
       
+      
 jobs:
   tutorial-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -15,7 +15,7 @@ on:
       - "**.py"
       - "**.ipynb"
       - "requirements*.txt"
-
+      
 jobs:
   tutorial-tests:
     runs-on: ubuntu-latest
@@ -25,6 +25,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -17,6 +17,7 @@ on:
       - "requirements*.txt"
       
       
+      
 jobs:
   tutorial-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -17,7 +17,6 @@ on:
       - "requirements*.txt"
       
       
-      
 jobs:
   tutorial-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description


Closes #102 

- Used Github Action's Cancel run workflow: ```cancel-workflow-action@0.9.0```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- On pushing 2 commits to the repository 
- Action 1 will start to build. Action 2 starts after a few seconds. On running the cancel workflow, Action 1 will get canceled. 
- Typically, any previous workflows will be canceled on a new push to the repository

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
-  [x] My changes are covered by tests
@gmuraru 
