### PR TITLE
fix: benchmark output file path

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -52,6 +52,6 @@ jobs:
         with:
           name: Pytest-benchmarks
           tool: "pytest"
-          output-file-path: tests/benchmarks/pytest_benchmarks_output.json
+          output-file-path: benchmarks/pytest_benchmarks_output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true


### PR DESCRIPTION
## Description
Currently, the benchmark action fails because it is trying to take the benchmark results from an incorrect path. This PR fixes this behaviour.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests