### PR TITLE
Disable CUDA when using FSS

### DIFF
--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -5,6 +5,8 @@ arXiv:2006.04593 [cs.LG]
 """
 # stdlib
 import multiprocessing
+import os
+import warnings
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -39,9 +41,7 @@ dif = sycret.LeFactory(n_threads=N_CORES)
 
 
 # share level
-def mask_builder(
-    session: Session, x1: ShareTensor, x2: ShareTensor, op: str
-) -> ShareTensor:
+def mask_builder(session: Session, x1: ShareTensor, x2: ShareTensor, op: str) -> ShareTensor:
     """Mask the private inputs.
 
     Add the share of alpha (the mask) that is held in the crypto store to
@@ -60,9 +60,7 @@ def mask_builder(
     """
     x = x1 - x2
 
-    keys = session.crypto_store.get_primitives_from_store(
-        f"fss_{op}", nr_instances=x.numel(), remove=False
-    )
+    keys = session.crypto_store.get_primitives_from_store(f"fss_{op}", nr_instances=x.numel(), remove=False)
 
     n_bytes = n // 8  # keys contains bytes not bits
     alpha = np.frombuffer(np.ascontiguousarray(keys[:, 0:n_bytes]), dtype=np.uint32)
@@ -87,9 +85,7 @@ def evaluate(session: Session, b, x_masked, op, dtype="long") -> ShareTensor:
         ShareTensor: A share of the result of the FSS protocol.
     """
     numel = x_masked.numel()
-    keys = session.crypto_store.get_primitives_from_store(
-        f"fss_{op}", nr_instances=numel, remove=True
-    )
+    keys = session.crypto_store.get_primitives_from_store(f"fss_{op}", nr_instances=numel, remove=True)
 
     b = b.numpy().item()
     original_shape = x_masked.shape
@@ -124,7 +120,11 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
     Returns:
         MPCTensor: Shares of the comparison.
     """
-    assert not th.cuda.is_available()  # nosec
+    if th.cuda.is_available():
+        # FSS is currently not supported on GPU.
+        # https://stackoverflow.com/a/62145307/8878627
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+        warnings.warn("CUDA has been disabled as FSS currently does not support it")
 
     # FIXME: Better handle the case where x1 or x2 is not a MPCTensor. For the moment
     # FIXME: we cast it into a MPCTensor at the expense of extra communication
@@ -151,9 +151,7 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
     mask_value = mask_value.reconstruct(decode=False) % 2 ** n
 
     # TODO: add dtype to args
-    args = [
-        (session.session_ptrs[i], th.IntTensor([i]), mask_value, op) for i in range(2)
-    ]
+    args = [(session.session_ptrs[i], th.IntTensor([i]), mask_value, op) for i in range(2)]
 
     shares = parallel_execution(evaluate, session.parties)(args)
 
@@ -273,8 +271,7 @@ def _get_primitive(
         return primitive
     else:
         raise ValueError(
-            f"Not enough primitives for fss: {nr_instances} required, "
-            f"but only {available_instances} available"
+            f"Not enough primitives for fss: {nr_instances} required, " f"but only {available_instances} available"
         )
 
 
@@ -299,14 +296,10 @@ def add_primitive(store: Dict[Any, Any], primitives: Iterable[Any]):  # noqa
 
 
 @register_primitive_store_get("fss_eq")
-def get_primitive(
-    store: Dict[Any, Any], nr_instances: int, remove: bool = True, **kwargs
-) -> Any:  # noqa
+def get_primitive(store: Dict[Any, Any], nr_instances: int, remove: bool = True, **kwargs) -> Any:  # noqa
     return _get_primitive("fss_eq", store, nr_instances, remove, **kwargs)
 
 
 @register_primitive_store_get("fss_comp")
-def get_primitive(
-    store: Dict[Any, Any], nr_instances: int, remove: bool = True, **kwargs
-) -> Any:  # noqa
+def get_primitive(store: Dict[Any, Any], nr_instances: int, remove: bool = True, **kwargs) -> Any:  # noqa
     return _get_primitive("fss_comp", store, nr_instances, remove, **kwargs)

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -129,14 +129,12 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
     if th.cuda.is_available():
         # FSS is currently not supported on GPU.
         # https://stackoverflow.com/a/62145307/8878627
-        try:
-            cuda_visible_devices = os.environ["CUDA_VISIBLE_DEVICES"]
-            os.environ["CUDA_VISIBLE_DEVICES"] = ""
-            warnings.warn("Temporarily disabling CUDA as FSS does not support it")
-        except KeyError:
-            # When the CUDA_VISIBLE_DEVICES environment variable is not set,
-            # CUDA is not used even if available
-            cuda_visible_devices = None
+
+        # When the CUDA_VISIBLE_DEVICES environment variable is not set,
+        # CUDA is not used even if available. Hence, we default to None
+        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+        warnings.warn("Temporarily disabling CUDA as FSS does not support it")
     else:
         cuda_visible_devices = None
 

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -6,12 +6,12 @@ arXiv:2006.04593 [cs.LG]
 # stdlib
 import multiprocessing
 import os
-import warnings
 from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Tuple
+import warnings
 
 # third party
 import numpy as np
@@ -41,7 +41,9 @@ dif = sycret.LeFactory(n_threads=N_CORES)
 
 
 # share level
-def mask_builder(session: Session, x1: ShareTensor, x2: ShareTensor, op: str) -> ShareTensor:
+def mask_builder(
+    session: Session, x1: ShareTensor, x2: ShareTensor, op: str
+) -> ShareTensor:
     """Mask the private inputs.
 
     Add the share of alpha (the mask) that is held in the crypto store to
@@ -60,7 +62,9 @@ def mask_builder(session: Session, x1: ShareTensor, x2: ShareTensor, op: str) ->
     """
     x = x1 - x2
 
-    keys = session.crypto_store.get_primitives_from_store(f"fss_{op}", nr_instances=x.numel(), remove=False)
+    keys = session.crypto_store.get_primitives_from_store(
+        f"fss_{op}", nr_instances=x.numel(), remove=False
+    )
 
     n_bytes = n // 8  # keys contains bytes not bits
     alpha = np.frombuffer(np.ascontiguousarray(keys[:, 0:n_bytes]), dtype=np.uint32)
@@ -85,7 +89,9 @@ def evaluate(session: Session, b, x_masked, op, dtype="long") -> ShareTensor:
         ShareTensor: A share of the result of the FSS protocol.
     """
     numel = x_masked.numel()
-    keys = session.crypto_store.get_primitives_from_store(f"fss_{op}", nr_instances=numel, remove=True)
+    keys = session.crypto_store.get_primitives_from_store(
+        f"fss_{op}", nr_instances=numel, remove=True
+    )
 
     b = b.numpy().item()
     original_shape = x_masked.shape
@@ -151,7 +157,9 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
     mask_value = mask_value.reconstruct(decode=False) % 2 ** n
 
     # TODO: add dtype to args
-    args = [(session.session_ptrs[i], th.IntTensor([i]), mask_value, op) for i in range(2)]
+    args = [
+        (session.session_ptrs[i], th.IntTensor([i]), mask_value, op) for i in range(2)
+    ]
 
     shares = parallel_execution(evaluate, session.parties)(args)
 
@@ -271,7 +279,8 @@ def _get_primitive(
         return primitive
     else:
         raise ValueError(
-            f"Not enough primitives for fss: {nr_instances} required, " f"but only {available_instances} available"
+            f"Not enough primitives for fss: {nr_instances} required, "
+            f"but only {available_instances} available"
         )
 
 
@@ -296,10 +305,14 @@ def add_primitive(store: Dict[Any, Any], primitives: Iterable[Any]):  # noqa
 
 
 @register_primitive_store_get("fss_eq")
-def get_primitive(store: Dict[Any, Any], nr_instances: int, remove: bool = True, **kwargs) -> Any:  # noqa
+def get_primitive(
+    store: Dict[Any, Any], nr_instances: int, remove: bool = True, **kwargs
+) -> Any:  # noqa
     return _get_primitive("fss_eq", store, nr_instances, remove, **kwargs)
 
 
 @register_primitive_store_get("fss_comp")
-def get_primitive(store: Dict[Any, Any], nr_instances: int, remove: bool = True, **kwargs) -> Any:  # noqa
+def get_primitive(
+    store: Dict[Any, Any], nr_instances: int, remove: bool = True, **kwargs
+) -> Any:  # noqa
     return _get_primitive("fss_comp", store, nr_instances, remove, **kwargs)


### PR DESCRIPTION
## Description
`assert not th.cuda.is_available()` makes FSS unusable on devices which have a GPU as it just exits due to the `AssertionError`. It is better to just disable the GPU and warn the user while doing so. 

## Reference
https://stackoverflow.com/a/62145307/8878627
## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
