### PR TITLE
POC sharing at protocol level

### DIFF
--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -180,6 +180,8 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
 class FSS(metaclass=Protocol):
     """Function Secret Sharing."""
 
+    tensor_class = ShareTensor
+
     @staticmethod
     def eq(x1: MPCTensor, x2: MPCTensor) -> MPCTensor:
         """Equal operator.
@@ -205,6 +207,19 @@ class FSS(metaclass=Protocol):
             MPCTensor: Shares of the comparison.
         """
         return fss_op(x1, x2, "comp")
+
+    @staticmethod
+    def distribute_shares(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
+        """Forward the call to the tensor specific class.
+
+        Args:
+            *args (List[Any]): list of args to be forwarded
+            **kwargs(Dict[str, Any): list of named args to be forwarded
+
+        Returns:
+            The result returned by the tensor specific distribute_shares method
+        """
+        return FSS.tensor_class.distribute_shares(*args, **kwargs)
 
 
 """ Register Crypto Store capabilities for FSS """

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -27,6 +27,7 @@ from sympc.store import register_primitive_store_add
 from sympc.store import register_primitive_store_get
 from sympc.tensor import MPCTensor
 from sympc.tensor import ShareTensor
+from sympc.tensor.tensor import SyMPCTensor
 from sympc.utils import parallel_execution
 
 ttp_generator = csprng.create_random_device_generator()
@@ -180,7 +181,8 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
 class FSS(metaclass=Protocol):
     """Function Secret Sharing."""
 
-    tensor_class = ShareTensor
+    """ Used for Share Level static operations like distrubuting the shares."""
+    share_class: SyMPCTensor = ShareTensor
 
     @staticmethod
     def eq(x1: MPCTensor, x2: MPCTensor) -> MPCTensor:
@@ -219,7 +221,7 @@ class FSS(metaclass=Protocol):
         Returns:
             The result returned by the tensor specific distribute_shares method
         """
-        return FSS.tensor_class.distribute_shares(*args, **kwargs)
+        return FSS.share_class.distribute_shares(*args, **kwargs)
 
 
 """ Register Crypto Store capabilities for FSS """

--- a/src/sympc/protocol/protocol.py
+++ b/src/sympc/protocol/protocol.py
@@ -24,8 +24,18 @@ class Protocol(type):
 
         Returns:
             Protocol: Defined protocol.
+
+        Raises:
+            ValueError: if the protocol we want to register does not have a 'share_class' attribute
+                        if the protocol is already registered with the same name
         """
         new_cls = super().__new__(cls, name, bases, dct)
+
+        if getattr(new_cls, "share_class", None) is None:
+            raise ValueError(
+                "share_class attribut should be present in the protocol class"
+            )
+
         Protocol.registered_protocols[name] = new_cls
 
         def __init__(self, *args: List[Any], **kwargs: Dict[Any, Any]) -> None:  # noqa

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -13,7 +13,6 @@ from typing import Tuple
 from typing import Union
 
 # third party
-from syft.core.node.common.client import Client
 import torch
 import torchcsprng as csprng  # type: ignore
 
@@ -189,7 +188,9 @@ class MPCTensor(metaclass=SyMPCTensor):
                 )
 
         if not ispointer(shares[0]):
-            shares = MPCTensor.distribute_shares(shares, self.session.parties)
+            shares = self.session.protocol.distribute_shares(
+                shares, self.session.parties
+            )
 
         self.share_ptrs = shares
 
@@ -204,23 +205,6 @@ class MPCTensor(metaclass=SyMPCTensor):
         self.grad = None
         self.grad_fn = None
         self.parents: List["MPCTensor"] = []
-
-    @staticmethod
-    def distribute_shares(shares: List[ShareTensor], parties: List[Client]):
-        """Distribute a list of shares.
-
-        Args:
-            shares (List[ShareTensor): list of shares to distribute.
-            parties (List[Client]): list to parties to distribute.
-
-        Returns:
-            List of ShareTensorPointers.
-        """
-        share_ptrs = []
-        for share, party in zip(shares, parties):
-            share_ptrs.append(share.send(party))
-
-        return share_ptrs
 
     @staticmethod
     def sanity_checks(

--- a/src/sympc/tensor/share_tensor.py
+++ b/src/sympc/tensor/share_tensor.py
@@ -11,6 +11,7 @@ from typing import Set
 from typing import Union
 
 # third party
+from syft.core.node.common.client import Client
 import torch
 
 from sympc.encoder import FixedPointEncoder
@@ -445,6 +446,23 @@ class ShareTensor(metaclass=SyMPCTensor):
             res = method
 
         return res
+
+    @staticmethod
+    def distribute_shares(shares: List["ShareTensor"], parties: List[Client]):
+        """Distribute a list of shares.
+
+        Args:
+            shares (List[ShareTensor): list of shares to distribute.
+            parties (List[Client]): list to parties to distribute.
+
+        Returns:
+            List of ShareTensorPointers.
+        """
+        share_ptrs = []
+        for share, party in zip(shares, parties):
+            share_ptrs.append(share.send(party))
+
+        return share_ptrs
 
     __add__ = add
     __radd__ = add

--- a/tests/sympc/protocol/fss/fss_test.py
+++ b/tests/sympc/protocol/fss/fss_test.py
@@ -1,0 +1,20 @@
+# third party
+import torch
+
+from sympc.protocol import FSS
+from sympc.tensor import MPCTensor
+from sympc.tensor import ShareTensor
+from sympc.utils import ispointer
+
+
+def test_share_tensor(get_clients) -> None:
+    assert FSS.share_class == ShareTensor
+
+    clients = get_clients(3)
+
+    secret = torch.tensor([-1, 0, 1])
+    shares = MPCTensor.generate_shares(secret, nr_parties=3)
+
+    distributed_shares = FSS.distribute_shares(shares, parties=clients)
+
+    assert all(ispointer(share_ptr) for share_ptr in distributed_shares)

--- a/tests/sympc/protocol/protocol_test.py
+++ b/tests/sympc/protocol/protocol_test.py
@@ -8,15 +8,23 @@ from sympc.protocol.beaver.beaver import mul_store_get
 from sympc.protocol.fss.fss import _generate_primitive
 from sympc.protocol.fss.fss import get_primitive
 from sympc.store.exceptions import EmptyPrimitiveStore
+from sympc.tensor import ShareTensor
 
 
 class TestProtocol(metaclass=Protocol):
-    pass
+    share_class = ShareTensor
 
 
 def test_register_protocol() -> None:
     assert "TestProtocol" in Protocol.registered_protocols
     assert Protocol.registered_protocols["TestProtocol"] == TestProtocol
+
+
+def test_exception_no_share_class() -> None:
+    with pytest.raises(ValueError):
+
+        class TestProtocolException(metaclass=Protocol):
+            ...
 
 
 def test_exception_unsupported_fss_operation():


### PR DESCRIPTION
## Description
Move the distribution of the share on a protocol basis because each protocol might have a different version of how it implements sharing. Falcon uses RSS and each party holds 2 shares.

## How has this been tested?
- it should already be tested

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
