### PR TITLE
Use Session UUID for retrieving session in parties

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,10 +56,3 @@ jobs:
         run: |
           bandit -r src
           safety check
-
-      - name: Snyk security check
-        uses: snyk/actions/python-3.8@master
-        env:
-          SNYK_TOKEN: ${{secrets.SNYK_TOKEN}} 
-        with:
-          args: --skip-unresolved

--- a/src/sympc/__init__.py
+++ b/src/sympc/__init__.py
@@ -55,5 +55,4 @@ except DistributionNotFound:
 finally:
     del get_distribution, DistributionNotFound
 
-
 add_methods_tensor_syft()

--- a/src/sympc/algorithms/__init__.py
+++ b/src/sympc/algorithms/__init__.py
@@ -1,3 +1,1 @@
 """Applications of primitive MPC operations."""
-
-from . import algorithms

--- a/src/sympc/api.py
+++ b/src/sympc/api.py
@@ -63,6 +63,8 @@ allowed_external_attrs = [
     ("sympc.store.CryptoStore.get_primitives_from_store", "syft.lib.python.List"),
     ("sympc.store.CryptoStore.store", "syft.lib.python.Dict"),
     ("sympc.session.Session.crypto_store", "sympc.store.CryptoStore"),
+    ("sympc.session.Session.init_generators", "syft.lib.python._SyNone"),
+    ("sympc.session.Session.przs_generators", "syft.lib.python.List"),
     ("sympc.protocol.fss.fss.mask_builder", "sympc.tensor.ShareTensor"),
     ("sympc.protocol.fss.fss.evaluate", "sympc.tensor.ShareTensor"),
     ("sympc.protocol.spdz.spdz.mul_parties", "sympc.tensor.ShareTensor"),

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -20,13 +20,13 @@ import torch as th
 import torchcsprng as csprng  # type: ignore
 
 from sympc.protocol.protocol import Protocol
+from sympc.session import get_session
 from sympc.store import CryptoPrimitiveProvider
 from sympc.store import register_primitive_generator
 from sympc.store import register_primitive_store_add
 from sympc.store import register_primitive_store_get
 from sympc.tensor import MPCTensor
 from sympc.tensor import ShareTensor
-from sympc.utils import get_session
 from sympc.utils import parallel_execution
 
 ttp_generator = csprng.create_random_device_generator()

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -27,7 +27,7 @@ from sympc.store import register_primitive_store_add
 from sympc.store import register_primitive_store_get
 from sympc.tensor import MPCTensor
 from sympc.tensor import ShareTensor
-from sympc.tensor.tensor import SyMPCTensor
+from sympc.utils import get_session
 from sympc.utils import parallel_execution
 
 ttp_generator = csprng.create_random_device_generator()
@@ -153,7 +153,7 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
         p_kwargs={},
     )
 
-    args = zip(session.session_ptrs, x1.share_ptrs, x2.share_ptrs)
+    args = zip(x1.share_ptrs, x2.share_ptrs)
     args = [list(el) + [op] for el in args]
 
     shares = parallel_execution(mask_builder, session.parties)(args)
@@ -163,14 +163,61 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
     mask_value = mask_value.reconstruct(decode=False) % 2 ** n
 
     # TODO: add dtype to args
-    args = [
-        (session.session_ptrs[i], th.IntTensor([i]), mask_value, op) for i in range(2)
-    ]
+    args = [(th.IntTensor([i]), mask_value, op) for i in range(2)]
 
     shares = parallel_execution(evaluate, session.parties)(args)
 
     response = MPCTensor(session=session, shares=shares, shape=shape)
     response.shape = shape
+
+    return response
+
+
+# share level
+def mask_builder(x1: ShareTensor, x2: ShareTensor, op: str) -> ShareTensor:
+    x = x1 - x2
+
+    session = get_session()
+
+    keys = session.crypto_store.get_primitives_from_store(
+        f"fss_{op}", nr_instances=x.numel(), remove=False
+    )
+
+    alpha = np.frombuffer(np.ascontiguousarray(keys[:, 0:N]), dtype=np.uint32)
+
+    x.tensor += th.tensor(alpha.astype(np.int64)).reshape(x.shape)
+
+    return x
+
+
+# share level
+def evaluate(b, x_masked, op, dtype="long") -> ShareTensor:
+    session = get_session()
+
+    if op == "eq":
+        return eq_evaluate(session, b, x_masked)
+    elif op == "comp":
+        return comp_evaluate(session, b, x_masked, dtype=dtype)
+    else:
+        raise ValueError
+
+
+# process level
+def eq_evaluate(session: Session, b, x_masked) -> ShareTensor:
+
+    numel = x_masked.numel()
+    keys = session.crypto_store.get_primitives_from_store(
+        "fss_eq", nr_instances=numel, remove=True
+    )
+
+    result = DPF.eval(b.numpy().item(), x_masked.numpy(), keys)
+
+    share_result = ShareTensor(
+        data=th.tensor(result), session=session
+    )  # TODO add dtype like in comp_evaluate
+
+    return share_result
+>>>>>>> ebbbf49... - add get_session function to utils.py
 
     if cuda_visible_devices is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -108,11 +108,8 @@ def evaluate(session: Session, b, x_masked, op, dtype="long") -> ShareTensor:
     dtype_options = {None: th.long, "int": th.int32, "long": th.long}
     result = th.tensor(result_share, dtype=dtype_options[dtype])
 
-    # stdlib
-    import dataclasses
-
     share_result = ShareTensor(
-        data=result, session_uuid=session.uuid, **dataclasses.asdict(session.config)
+        data=result, session_uuid=session.uuid, config=session.config
     )
 
     return share_result

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -20,7 +20,7 @@ import torch as th
 import torchcsprng as csprng  # type: ignore
 
 from sympc.protocol.protocol import Protocol
-from sympc.session.session_utils import get_session
+from sympc.session import get_session
 from sympc.store import CryptoPrimitiveProvider
 from sympc.store import register_primitive_generator
 from sympc.store import register_primitive_store_add

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -20,7 +20,6 @@ import torch as th
 import torchcsprng as csprng  # type: ignore
 
 from sympc.protocol.protocol import Protocol
-from sympc.session import Session
 from sympc.store import CryptoPrimitiveProvider
 from sympc.store import register_primitive_generator
 from sympc.store import register_primitive_store_add
@@ -59,6 +58,8 @@ def mask_builder(x1: ShareTensor, x2: ShareTensor, op: str) -> ShareTensor:
     Returns:
         ShareTensor: share of the masked input
     """
+    session = get_session()
+
     x = x1 - x2
 
     keys = session.crypto_store.get_primitives_from_store(
@@ -87,6 +88,11 @@ def evaluate(session: Session, b, x_masked, op, dtype="long") -> ShareTensor:
     Returns:
         ShareTensor: A share of the result of the FSS protocol.
     """
+<<<<<<< HEAD
+=======
+    session = get_session()
+
+>>>>>>> 9edf6d3... remove Session import from fss
     numel = x_masked.numel()
     keys = session.crypto_store.get_primitives_from_store(
         f"fss_{op}", nr_instances=numel, remove=True

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -20,7 +20,7 @@ import torch as th
 import torchcsprng as csprng  # type: ignore
 
 from sympc.protocol.protocol import Protocol
-from sympc.session import get_session
+from sympc.session.session_utils import get_session
 from sympc.store import CryptoPrimitiveProvider
 from sympc.store import register_primitive_generator
 from sympc.store import register_primitive_store_add

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -42,9 +42,7 @@ dif = sycret.LeFactory(n_threads=N_CORES)
 
 
 # share level
-def mask_builder(
-    session: Session, x1: ShareTensor, x2: ShareTensor, op: str
-) -> ShareTensor:
+def mask_builder(x1: ShareTensor, x2: ShareTensor, op: str) -> ShareTensor:
     """Mask the private inputs.
 
     Add the share of alpha (the mask) that is held in the crypto store to

--- a/src/sympc/protocol/spdz/spdz.py
+++ b/src/sympc/protocol/spdz/spdz.py
@@ -59,17 +59,12 @@ def mul_master(
 
     args = [list(el) + [op_str] for el in zip(x.share_ptrs, y.share_ptrs)]
 
-    args = [
-        list(el) + [op_str]
-        for el in zip(session.session_ptrs, x.share_ptrs, y.share_ptrs)
-    ]
-
     try:
         mask = parallel_execution(spdz_mask, session.parties)(args)
     except EmptyPrimitiveStore:
         CryptoPrimitiveProvider.generate_primitives(
             f"beaver_{op_str}",
-            sessions=session.session_ptrs,
+            session=session,
             g_kwargs={
                 "a_shape": shape_x,
                 "b_shape": shape_y,

--- a/src/sympc/protocol/spdz/spdz.py
+++ b/src/sympc/protocol/spdz/spdz.py
@@ -17,7 +17,7 @@ from typing import Union
 # third party
 import torch
 
-from sympc.session import get_session
+from sympc.session.session_utils import get_session
 from sympc.store import CryptoPrimitiveProvider
 from sympc.store.exceptions import EmptyPrimitiveStore
 from sympc.tensor import MPCTensor

--- a/src/sympc/protocol/spdz/spdz.py
+++ b/src/sympc/protocol/spdz/spdz.py
@@ -17,12 +17,12 @@ from typing import Union
 # third party
 import torch
 
+from sympc.session import get_session
 from sympc.store import CryptoPrimitiveProvider
 from sympc.store.exceptions import EmptyPrimitiveStore
 from sympc.tensor import MPCTensor
 from sympc.tensor import ShareTensor
 from sympc.utils import count_wraps
-from sympc.utils import get_session
 from sympc.utils import parallel_execution
 
 EXPECTED_OPS = {"mul", "matmul", "conv2d", "conv_transpose2d"}

--- a/src/sympc/protocol/spdz/spdz.py
+++ b/src/sympc/protocol/spdz/spdz.py
@@ -17,7 +17,7 @@ from typing import Union
 # third party
 import torch
 
-from sympc.session.session_utils import get_session
+from sympc.session import get_session
 from sympc.store import CryptoPrimitiveProvider
 from sympc.store.exceptions import EmptyPrimitiveStore
 from sympc.tensor import MPCTensor

--- a/src/sympc/protocol/spdz/spdz.py
+++ b/src/sympc/protocol/spdz/spdz.py
@@ -264,8 +264,6 @@ def mul_parties(
     # Step 2. Divide by scale
     # This is done here to reduce one round of communication
     if session.nr_parties == 2:
-        print(share.fp_encoder.precision)
-        print(share.fp_encoder.scale)
         share.tensor //= share.fp_encoder.scale
 
     return share

--- a/src/sympc/session/__init__.py
+++ b/src/sympc/session/__init__.py
@@ -1,11 +1,14 @@
 """Session class and utility functions used in conjunction with the session."""
+# stdlib
+from typing import Dict
 
 from .session import Session
 from .session_manager import SessionManager
 from .session_utils import get_session
+from .session_utils import set_session
 
-__all__ = [
-    "Session",
-    "SessionManager",
-    "get_session",
-]
+# Mapping for rank -> Session
+# rank is needed in the case we have VirtualMachines since we share the same workspace
+CURRENT_SESSION: Dict[int, Session] = {}
+
+__all__ = ["Session", "SessionManager", "get_session", "set_session"]

--- a/src/sympc/session/__init__.py
+++ b/src/sympc/session/__init__.py
@@ -1,7 +1,11 @@
 """Session class and utility functions used in conjunction with the session."""
 
 from .session import Session
-from .session import get_session
 from .session_manager import SessionManager
+from .session_utils import get_session
 
-__all__ = ["Session", "get_session", "SessionManager"]
+__all__ = [
+    "Session",
+    "SessionManager",
+    "get_session",
+]

--- a/src/sympc/session/__init__.py
+++ b/src/sympc/session/__init__.py
@@ -7,8 +7,9 @@ from .session_manager import SessionManager
 from .session_utils import get_session
 from .session_utils import set_session
 
-# Mapping for rank -> Session
-# rank is needed in the case we have VirtualMachines since we share the same workspace
-CURRENT_SESSION: Dict[int, Session] = {}
+# Mapping for uuid_str -> Session
+# uuid_str is unique even for the same Session
+# this is needed in the case we have VirtualMachines since we share the same workspace
+CURRENT_SESSION: Dict[str, Session] = {}
 
 __all__ = ["Session", "SessionManager", "get_session", "set_session"]

--- a/src/sympc/session/__init__.py
+++ b/src/sympc/session/__init__.py
@@ -1,6 +1,7 @@
 """Session class and utility functions used in conjunction with the session."""
 
 from .session import Session
+from .session import get_session
 from .session_manager import SessionManager
 
-__all__ = ["Session", "SessionManager"]
+__all__ = ["Session", "get_session", "SessionManager"]

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -219,13 +219,3 @@ class Session:
             operator.attrgetter(attr) for attr in self.__slots__ - Session.NOT_COMPARE
         ]
         return all(getter(self) == getter(other) for getter in attr_getters)
-
-
-def get_session() -> Session:
-    """Gets the current session for a party as defined in the global space.
-
-    Returns:
-        Session: MPC Session
-    """
-    session = globals()["session"]
-    return session

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -219,3 +219,13 @@ class Session:
             operator.attrgetter(attr) for attr in self.__slots__ - Session.NOT_COMPARE
         ]
         return all(getter(self) == getter(other) for getter in attr_getters)
+
+
+def get_session() -> Session:
+    """Gets the current session for a party as defined in the global space.
+
+    Returns:
+        Session: MPC Session
+    """
+    session = globals()["session"]
+    return session

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -4,9 +4,7 @@ This class holds the static methods used for the Session.
 """
 
 # stdlib
-import operator
 import secrets
-from typing import Any
 from typing import Dict
 from uuid import UUID
 from uuid import uuid4
@@ -92,18 +90,3 @@ class SessionManager:
         for rank, remote_session in enumerate(session.session_ptrs):
             next_rank = (rank + 1) % session.nr_parties
             remote_session.init_generators(seeds[rank], seeds[next_rank])
-
-    def __eq__(self, other: Any) -> bool:
-        """Check if "self" is equal with another object given a set of attributes to compare.
-
-        Args:
-            other (Any): Session to compare.
-
-        Returns:
-            Bool. True if equal False if not.
-        """
-        if not isinstance(other, self.__class__):
-            return False
-
-        attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
-        return all(getter(self) == getter(other) for getter in attr_getters)

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -7,7 +7,7 @@ This class holds the static methods used for the Session.
 import operator
 import secrets
 from typing import Any
-from typing import Optional
+from typing import Dict
 from uuid import UUID
 from uuid import uuid4
 
@@ -27,18 +27,13 @@ class SessionManager:
 
     def __init__(
         self,
-        uuid: Optional[UUID] = None,
     ) -> None:
         """Initializer for the Session Manager.
 
-        Args:
-            uuid (Optional[UUID]): Universal identifier of a session manager instance.
+        Raises:
+            NotImplementedError: This class it is not supposed to be instanciated.
         """
-        self.uuid = uuid4() if uuid is None else uuid
-
-        # Each worker will have the rank as the index in the list
-        # Only the party that is the CC (Control Center) will have access
-        # to this
+        raise NotImplementedError("This is not suposed to be instanciated!")
 
     @staticmethod
     def setup_mpc(session: Session) -> None:
@@ -50,11 +45,19 @@ class SessionManager:
         Args:
             session (Session): Session to send.
         """
+        uuids: Dict[int, UUID] = {}
         for rank, party in enumerate(session.parties):
             # Assign a new rank before sending it to another party
-            session.rank = rank
-            session.session_ptrs.append(session.send(party))  # type: ignore
+            session_party = session.copy()
+            session_party.rank = rank
 
+            # And a new uuid
+            session_party.uuid = uuid4()
+            uuids[rank] = session_party.uuid
+            session.session_ptrs.append(session_party.send(party))  # type: ignore
+
+        session.uuid = uuid4()
+        session.rank_to_uuid = uuids
         SessionManager._setup_przs(session)
 
     @staticmethod
@@ -84,24 +87,11 @@ class SessionManager:
         Args:
             session (Session): Session involved in the communication.
         """
-        nr_parties = len(session.parties)
+        seeds = [secrets.randbits(32) for _ in range(session.nr_parties)]
 
-        # Create the remote lists where we add the generators
-        session.przs_generators = [
-            party.python.List([None, None]) for party in session.parties
-        ]
-
-        parties = session.parties
-
-        for rank in range(nr_parties):
-            seed = secrets.randbits(32)
-            next_rank = (rank + 1) % nr_parties
-
-            gen_current = session.parties[rank].sympc.utils.get_new_generator(seed)
-            gen_next = parties[next_rank].sympc.utils.get_new_generator(seed)
-
-            session.przs_generators[rank][1] = gen_current
-            session.przs_generators[next_rank][0] = gen_next
+        for rank, remote_session in enumerate(session.session_ptrs):
+            next_rank = (rank + 1) % session.nr_parties
+            remote_session.init_generators(seeds[rank], seeds[next_rank])
 
     def __eq__(self, other: Any) -> bool:
         """Check if "self" is equal with another object given a set of attributes to compare.

--- a/src/sympc/session/session_utils.py
+++ b/src/sympc/session/session_utils.py
@@ -1,14 +1,29 @@
 """Function for accessing the current session."""
+# stdlib
+from typing import Optional
 
 import sympc.session
 
 from .session import Session
 
 
-def get_session() -> Session:
+def get_session(uuid_str: str) -> Optional[Session]:
     """Gets the current session for a party as defined in the global space.
+
+    Args:
+        uuid_str (str): used to retrieve the session
 
     Returns:
         Session: MPC Session
     """
-    return sympc.session.current_session
+    return sympc.session.CURRENT_SESSION.get(uuid_str, None)
+
+
+def set_session(session: Session) -> None:
+    """Set the current sessionfor a party.
+
+    Args:
+        session (Session): session to be set
+
+    """
+    sympc.session.CURRENT_SESSION[str(session.uuid)] = session

--- a/src/sympc/session/session_utils.py
+++ b/src/sympc/session/session_utils.py
@@ -11,6 +11,4 @@ def get_session() -> Session:
     Returns:
         Session: MPC Session
     """
-    session = sympc.session.current_session
-    print("successfully retrieved:", sympc.session.current_session)
-    return session
+    return sympc.session.current_session

--- a/src/sympc/session/session_utils.py
+++ b/src/sympc/session/session_utils.py
@@ -1,0 +1,16 @@
+"""Function for accessing the current session."""
+
+import sympc.session
+
+from .session import Session
+
+
+def get_session() -> Session:
+    """Gets the current session for a party as defined in the global space.
+
+    Returns:
+        Session: MPC Session
+    """
+    session = sympc.session.current_session
+    print("successfully retrieved:", sympc.session.current_session)
+    return session

--- a/src/sympc/store/crypto_primitive_provider.py
+++ b/src/sympc/store/crypto_primitive_provider.py
@@ -1,6 +1,7 @@
 """Crypto Primitives."""
 
 # stdlib
+import itertools
 import json
 from typing import Any
 from typing import Callable
@@ -25,7 +26,7 @@ class CryptoPrimitiveProvider:
     @staticmethod
     def generate_primitives(
         op_str: str,
-        sessions: List[Any],
+        session: Session,
         g_kwargs: Dict[str, Any] = {},
         p_kwargs: Dict[str, Any] = {},
     ) -> List[Any]:
@@ -33,7 +34,7 @@ class CryptoPrimitiveProvider:
 
         Args:
             op_str (str): Operator.
-            sessions (Session): Session.
+            session (Session): Session.
             g_kwargs: Generate kwargs passed to the registered function.
             p_kwargs: Populate kwargs passed to the registered populate function.
 
@@ -50,6 +51,13 @@ class CryptoPrimitiveProvider:
         generator = CryptoPrimitiveProvider._func_providers[op_str]
         primitives = generator(**g_kwargs)
 
+        for remote_session_uuid, primitive in zip(
+            session.rank_to_uuid.values(), primitives
+        ):
+            print(remote_session_uuid)
+            for share in itertools.chain(*primitive):
+                share.session_uuid = remote_session_uuid
+
         if CryptoPrimitiveProvider._LOGGING:
             CryptoPrimitiveProvider._ops_list[op_str].append((p_kwargs, g_kwargs))
 
@@ -57,7 +65,7 @@ class CryptoPrimitiveProvider:
             """Do not transfer the primitives if there is not specified a
             values for populate kwargs."""
             CryptoPrimitiveProvider._transfer_primitives_to_parties(
-                op_str, primitives, sessions, p_kwargs
+                op_str, primitives, session.session_ptrs, p_kwargs
             )
 
         # Since we do not have (YET!) the possiblity to return typed tuples from a remote

--- a/src/sympc/store/crypto_primitive_provider.py
+++ b/src/sympc/store/crypto_primitive_provider.py
@@ -54,7 +54,6 @@ class CryptoPrimitiveProvider:
         for remote_session_uuid, primitive in zip(
             session.rank_to_uuid.values(), primitives
         ):
-            print(remote_session_uuid)
             for share in itertools.chain(*primitive):
                 share.session_uuid = remote_session_uuid
 
@@ -146,7 +145,7 @@ class CryptoPrimitiveProvider:
             for (p_kwargs, g_kwargs) in args:
                 CryptoPrimitiveProvider.generate_primitives(
                     op_str=op_str,
-                    sessions=session.session_ptrs,
+                    session=session,
                     g_kwargs=g_kwargs,
                     p_kwargs=p_kwargs,
                 )

--- a/src/sympc/tensor/grads/grad_functions.py
+++ b/src/sympc/tensor/grads/grad_functions.py
@@ -464,7 +464,7 @@ class GradConv2d(GradFunc):
             kernel_size=kernel_size,
             dilation=(dilation, dilation),
         )
-        share_tensor = ShareTensor(torch.tensor(new_tuple), session=session)
+        share_tensor = ShareTensor(torch.tensor(new_tuple), config=session.config)
         return share_tensor
 
     @staticmethod

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -190,7 +190,7 @@ class MPCTensor(metaclass=SyMPCTensor):
                 )
 
         if not ispointer(shares[0]):
-            shares = MPCTensor.distribute_shares(shares, self.session)
+            shares = self.session.protocol.distribute_shares(shares, self.session)
 
         self.share_ptrs = shares
 
@@ -205,28 +205,6 @@ class MPCTensor(metaclass=SyMPCTensor):
         self.grad = None
         self.grad_fn = None
         self.parents: List["MPCTensor"] = []
-
-    @staticmethod
-    def distribute_shares(shares: List[ShareTensor], session: Session):
-        """Distribute a list of shares.
-
-        Args:
-            shares (List[ShareTensor): list of shares to distribute.
-            session (Session): Session for which those shares were generated
-
-        Returns:
-            List of ShareTensorPointers.
-        """
-        rank_to_uuid = session.rank_to_uuid
-        parties = session.parties
-
-        share_ptrs = []
-        for rank, share in enumerate(shares):
-            share.session_uuid = rank_to_uuid[rank]
-            party = parties[rank]
-            share_ptrs.append(share.send(party))
-
-        return share_ptrs
 
     @staticmethod
     def sanity_checks(

--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -302,7 +302,7 @@ class MPCTensor(metaclass=SyMPCTensor):
     def generate_shares(
         secret: Union[ShareTensor, torch.Tensor, float, int],
         nr_parties: int,
-        config: Optional[Config] = None,
+        config: Config = Config(),
         tensor_type: Optional[torch.dtype] = None,
     ) -> List[ShareTensor]:
         """Generate shares from secret.
@@ -314,6 +314,7 @@ class MPCTensor(metaclass=SyMPCTensor):
             secret (Union[ShareTensor, torch.Tensor, float, int]): Secret to split.
             nr_parties (int): Number of parties to split the scret.
             config (Config): Configuration used for the Share Tensor (in case it is needed).
+                Use default Config if nothing provided. The ShareTensor config would have priority.
             tensor_type (torch.dtype, optional): tensor type. Defaults to None.
 
         Returns:

--- a/src/sympc/tensor/share_tensor.py
+++ b/src/sympc/tensor/share_tensor.py
@@ -93,7 +93,7 @@ class ShareTensor(metaclass=SyMPCTensor):
     def __init__(
         self,
         data: Optional[Union[float, int, torch.Tensor]] = None,
-        config: Config = Config(encoder_base=16, encoder_precision=2),
+        config: Config = Config(encoder_base=2, encoder_precision=16),
         session_uuid: Optional[UUID] = None,
         ring_size: int = 2 ** 64,
     ) -> None:
@@ -394,7 +394,13 @@ class ShareTensor(metaclass=SyMPCTensor):
         if not self.config == other.config:
             return False
 
-        if not (self.session_uuid == other.session_uuid):
+        if (
+            self.session_uuid
+            and other.session_uuid
+            and self.session_uuid != other.session_uuid
+        ):
+            # If both shares have a session_uuid we consider them not equal
+            # else they are
             return False
 
         return True

--- a/src/sympc/utils/__init__.py
+++ b/src/sympc/utils/__init__.py
@@ -5,6 +5,7 @@ from .mpc_utils import decompose
 from .mpc_utils import generate_random_element
 from .mpc_utils import get_new_generator
 from .mpc_utils import get_type_from_ring
+from .utils import get_session
 from .utils import islocal
 from .utils import ispointer
 from .utils import parallel_execution
@@ -13,6 +14,7 @@ __all__ = [
     "ispointer",
     "islocal",
     "parallel_execution",
+    "get_session",
     "count_wraps",
     "get_new_generator",
     "generate_random_element",

--- a/src/sympc/utils/__init__.py
+++ b/src/sympc/utils/__init__.py
@@ -5,7 +5,6 @@ from .mpc_utils import decompose
 from .mpc_utils import generate_random_element
 from .mpc_utils import get_new_generator
 from .mpc_utils import get_type_from_ring
-from .utils import get_session
 from .utils import islocal
 from .utils import ispointer
 from .utils import parallel_execution
@@ -14,7 +13,6 @@ __all__ = [
     "ispointer",
     "islocal",
     "parallel_execution",
-    "get_session",
     "count_wraps",
     "get_new_generator",
     "generate_random_element",

--- a/src/sympc/utils/utils.py
+++ b/src/sympc/utils/utils.py
@@ -15,6 +15,8 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
+from sympc.session import Session
+
 
 def ispointer(obj: Any) -> bool:
     """Check if a given obj is a pointer (is a remote object).
@@ -128,10 +130,11 @@ def parallel_execution(
     return wrapper
 
 
-def get_session():
+def get_session() -> Session:
     """Gets the current session for a party as defined in the global space.
 
-    :returns: Session
+    Returns:
+        Session: MPC Session
     """
     session = globals()["session"]
     return session

--- a/src/sympc/utils/utils.py
+++ b/src/sympc/utils/utils.py
@@ -126,3 +126,12 @@ def parallel_execution(
         return local_shares
 
     return wrapper
+
+
+def get_session():
+    """Gets the current session for a party as defined in the global space.
+
+    :returns: Session
+    """
+    session = globals()["session"]
+    return session

--- a/src/sympc/utils/utils.py
+++ b/src/sympc/utils/utils.py
@@ -15,8 +15,6 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
-from sympc.session import Session
-
 
 def ispointer(obj: Any) -> bool:
     """Check if a given obj is a pointer (is a remote object).
@@ -128,13 +126,3 @@ def parallel_execution(
         return local_shares
 
     return wrapper
-
-
-def get_session() -> Session:
-    """Gets the current session for a party as defined in the global space.
-
-    Returns:
-        Session: MPC Session
-    """
-    session = globals()["session"]
-    return session

--- a/tests/sympc/protocol/fss/fss_test.py
+++ b/tests/sympc/protocol/fss/fss_test.py
@@ -1,8 +1,9 @@
 # third party
 import torch
 
-from sympc.config import Config
 from sympc.protocol import FSS
+from sympc.session import Session
+from sympc.session import SessionManager
 from sympc.tensor import MPCTensor
 from sympc.tensor import ShareTensor
 from sympc.utils import ispointer
@@ -11,11 +12,12 @@ from sympc.utils import ispointer
 def test_share_tensor(get_clients) -> None:
     assert FSS.share_class == ShareTensor
 
-    clients = get_clients(3)
+    session = Session(parties=get_clients(3))
+    SessionManager.setup_mpc(session)
 
     secret = torch.tensor([-1, 0, 1])
-    shares = MPCTensor.generate_shares(secret, nr_parties=3, config=Config())
+    shares = MPCTensor.generate_shares(secret, nr_parties=3)
 
-    distributed_shares = FSS.distribute_shares(shares, parties=clients)
+    distributed_shares = FSS.distribute_shares(shares, session=session)
 
     assert all(ispointer(share_ptr) for share_ptr in distributed_shares)

--- a/tests/sympc/protocol/fss/fss_test.py
+++ b/tests/sympc/protocol/fss/fss_test.py
@@ -1,6 +1,7 @@
 # third party
 import torch
 
+from sympc.config import Config
 from sympc.protocol import FSS
 from sympc.tensor import MPCTensor
 from sympc.tensor import ShareTensor
@@ -13,7 +14,7 @@ def test_share_tensor(get_clients) -> None:
     clients = get_clients(3)
 
     secret = torch.tensor([-1, 0, 1])
-    shares = MPCTensor.generate_shares(secret, nr_parties=3)
+    shares = MPCTensor.generate_shares(secret, nr_parties=3, config=Config())
 
     distributed_shares = FSS.distribute_shares(shares, parties=clients)
 

--- a/tests/sympc/session/session_manager_test.py
+++ b/tests/sympc/session/session_manager_test.py
@@ -2,21 +2,19 @@
 
 # stdlib
 from uuid import UUID
-from uuid import uuid4
+
+# third party
+import pytest
 
 from sympc.session import Session
 from sympc.session import SessionManager
 
 
-def test_session_manager_init():
+def test_session_manager_throw_exception_init():
     """Test correct initialisation of the SessionManager class."""
     # Test default init
-    session = SessionManager()
-    assert isinstance(session.uuid, UUID)
-    # Test custom init
-    uuid = uuid4()
-    session = Session(uuid=uuid)
-    assert session.uuid == uuid
+    with pytest.raises(NotImplementedError):
+        SessionManager()
 
 
 def test_setup_mpc(get_clients):
@@ -24,27 +22,6 @@ def test_setup_mpc(get_clients):
     alice_client, bob_client = get_clients(2)
     session = Session(parties=[alice_client, bob_client])
     SessionManager.setup_mpc(session)
-    assert session.rank == 1
-    assert len(session.session_ptrs) == 2
-
-
-def test_setup_przs(get_clients):
-    """Test _setup_przs method for session."""
-    alice_client, bob_client = get_clients(2)
-    session = Session(parties=[alice_client, bob_client])
-    assert len(session.przs_generators) == 0
-    SessionManager._setup_przs(session)
-    assert len(session.przs_generators) == 2
-
-
-def test_eq():
-    """Test __eq__ for SessionManager."""
-    session_manager = SessionManager()
-    other1 = SessionManager()
-    other2 = session_manager
-    # Test different instances:
-    assert session_manager != 1
-    # Test different session_managers:
-    assert session_manager != other1
-    # Test equal session_managers:
-    assert session_manager == other2
+    assert isinstance(session.uuid, UUID)
+    assert list(session.rank_to_uuid.keys()) == [0, 1]
+    assert all(isinstance(e, UUID) for e in session.rank_to_uuid.values())

--- a/tests/sympc/session/session_test.py
+++ b/tests/sympc/session/session_test.py
@@ -1,8 +1,6 @@
 """Tests for the Session class."""
 
 # stdlib
-from uuid import UUID
-from uuid import uuid4
 
 # third party
 import pytest
@@ -16,11 +14,11 @@ from sympc.utils import get_new_generator
 from sympc.utils import get_type_from_ring
 
 
-def test_session_init():
+def test_session_default_init() -> None:
     """Test correct initialisation of the Sessin class."""
     # Test default init
     session = Session()
-    assert isinstance(session.uuid, UUID)
+    assert session.uuid is None
     assert session.parties == []
     assert session.trusted_third_party is None
     assert session.crypto_store is None
@@ -33,13 +31,14 @@ def test_session_init():
     assert session.ring_size == 2 ** 64
     assert session.min_value == -(2 ** 64) // 2
     assert session.max_value == (2 ** 64 - 1) // 2
-    # Test custom init
-    uuid = uuid4()
+
+
+def test_session_custom_init() -> None:
     config = Config()
     session = Session(
-        parties=["alice", "bob"], ring_size=2 ** 32, config=config, ttp="TTP", uuid=uuid
+        parties=["alice", "bob"], ring_size=2 ** 32, config=config, ttp="TTP"
     )
-    assert session.uuid == uuid
+    assert session.uuid is None
     assert session.parties == ["alice", "bob"]
     assert session.trusted_third_party == "TTP"
     assert session.crypto_store is None
@@ -54,37 +53,54 @@ def test_session_init():
     assert session.max_value == (2 ** 32 - 1) // 2
 
 
-def test_przs_generate_random_share(get_clients):
+def test_przs_generate_random_share(get_clients) -> None:
     """Test przs_generate_random_share method from Session."""
     session = Session()
     SessionManager.setup_mpc(session)
     gen1 = get_new_generator(42)
     gen2 = get_new_generator(43)
-    generators = [gen1, gen2]
-    share = session.przs_generate_random_share(shape=(2, 1), generators=generators)
+    session.przs_generators = [gen1, gen2]
+    share = session.przs_generate_random_share(shape=(2, 1))
     assert isinstance(share, ShareTensor)
     target_tensor = torch.tensor(([-1540733531777602634], [2813554787685566880]))
     assert (share.tensor == target_tensor).all()
 
 
-def test_eq():
+def test_eq() -> None:
     """Test __eq__ for Session."""
     session = Session()
     other1 = Session()
     other2 = session
+
     # Test different instances:
     assert session != 1
-    # Test different sessions:
-    assert session != other1
+
     # Test equal sessions:
     assert session == other2
 
+    # Test same sessions (until we call setup mpc):
+    assert session == other1
 
-def test_invalid_protocol_exception():
+    SessionManager.setup_mpc(session)
+
+    assert session != other1
+
+
+def test_copy() -> None:
+    session = Session()
+
+    copy_session = session.copy()
+
+    assert session.nr_parties == copy_session.nr_parties
+    assert session.config == copy_session.config
+    assert session.protocol == copy_session.protocol
+
+
+def test_invalid_protocol_exception() -> None:
     with pytest.raises(ValueError):
         Session(protocol="fs")
 
 
-def test_invalid_ringsize_exception():
+def test_invalid_ringsize_exception() -> None:
     with pytest.raises(ValueError):
         Session(ring_size=2 ** 63)

--- a/tests/sympc/store/crypto_primitive_provider_test.py
+++ b/tests/sympc/store/crypto_primitive_provider_test.py
@@ -18,6 +18,7 @@ from sympc.store import register_primitive_generator
 from sympc.store import register_primitive_store_add
 from sympc.store import register_primitive_store_get
 from sympc.tensor import MPCTensor
+from sympc.tensor import ShareTensor
 
 PRIMITIVE_NR_ELEMS = 4
 
@@ -41,7 +42,10 @@ def provider_test(nr_parties: int, nr_instances: int) -> List[Tuple[int]]:
     ...]
     """
     primitives = [
-        tuple(tuple(i for _ in range(PRIMITIVE_NR_ELEMS)) for _ in range(nr_instances))
+        tuple(
+            tuple(ShareTensor(data=i) for _ in range(PRIMITIVE_NR_ELEMS))
+            for _ in range(nr_instances)
+        )
         for i in range(nr_parties)
     ]
     return primitives
@@ -69,7 +73,7 @@ def test_exception_init() -> None:
 
 def test_generate_primitive_exception() -> None:
     with pytest.raises(ValueError):
-        CryptoPrimitiveProvider.generate_primitives(op_str="SyMPC", sessions=[])
+        CryptoPrimitiveProvider.generate_primitives(op_str="SyMPC", session=Session())
 
 
 def test_transfer_primitives_type_exception() -> None:
@@ -108,7 +112,7 @@ def test_generate_primitive(
     g_kwargs = {"nr_parties": nr_parties, "nr_instances": nr_instances}
     res = CryptoPrimitiveProvider.generate_primitives(
         "test",
-        sessions=session.session_ptrs,
+        session=session,
         g_kwargs=g_kwargs,
         p_kwargs=None,
     )
@@ -118,7 +122,7 @@ def test_generate_primitive(
 
     for i, primitives in enumerate(res):
         for primitive in primitives:
-            assert primitive == tuple(i for _ in range(PRIMITIVE_NR_ELEMS))
+            assert primitive == tuple(ShareTensor(i) for _ in range(PRIMITIVE_NR_ELEMS))
 
 
 @pytest.mark.parametrize(
@@ -139,7 +143,7 @@ def test_generate_and_transfer_primitive(
     g_kwargs = {"nr_parties": nr_parties, "nr_instances": nr_instances}
     CryptoPrimitiveProvider.generate_primitives(
         "test",
-        sessions=session.session_ptrs,
+        session=session,
         g_kwargs=g_kwargs,
         p_kwargs={},
     )
@@ -150,7 +154,7 @@ def test_generate_and_transfer_primitive(
             op_str="test", nr_instances=nr_instances_retrieve
         ).get()
         assert primitives == [
-            tuple(i for _ in range(PRIMITIVE_NR_ELEMS))
+            tuple(ShareTensor(i) for _ in range(PRIMITIVE_NR_ELEMS))
             for _ in range(nr_instances_retrieve)
         ]
 
@@ -203,7 +207,7 @@ def test_primitive_logging_beaver_mul(get_clients) -> None:
 
     CryptoPrimitiveProvider.start_logging()
     CryptoPrimitiveProvider.generate_primitives(
-        sessions=session.session_ptrs,
+        session=session,
         op_str="beaver_mul",
         p_kwargs=p_kwargs,
         g_kwargs=g_kwargs,
@@ -224,7 +228,7 @@ def test_primitive_logging_beaver_matmul(get_clients) -> None:
 
     CryptoPrimitiveProvider.start_logging()
     CryptoPrimitiveProvider.generate_primitives(
-        sessions=session.session_ptrs,
+        session=session,
         op_str="beaver_matmul",
         p_kwargs=p_kwargs,
         g_kwargs=g_kwargs,
@@ -245,7 +249,7 @@ def test_primitive_logging_beaver_conv2d(get_clients) -> None:
 
     CryptoPrimitiveProvider.start_logging()
     CryptoPrimitiveProvider.generate_primitives(
-        sessions=session.session_ptrs,
+        session=session,
         op_str="beaver_conv2d",
         p_kwargs=p_kwargs,
         g_kwargs=g_kwargs,

--- a/tests/sympc/tensor/mpc_tensor_test.py
+++ b/tests/sympc/tensor/mpc_tensor_test.py
@@ -124,9 +124,6 @@ def test_local_secret_not_tensor(get_clients) -> None:
     assert np.allclose(torch.tensor(x_float), result)
 
 
-"""
-
-
 @pytest.mark.parametrize("nr_clients", [2, 3, 4, 5])
 @pytest.mark.parametrize("op_str", ["mul", "matmul"])
 def test_ops_mpc_mpc(get_clients, nr_clients, op_str) -> None:
@@ -144,9 +141,6 @@ def test_ops_mpc_mpc(get_clients, nr_clients, op_str) -> None:
     expected_result = op(x_secret, y_secret)
 
     assert np.allclose(result, expected_result, rtol=10e-4)
-
-
-"""
 
 
 @pytest.mark.parametrize("nr_clients", [2])
@@ -236,9 +230,6 @@ def test_ops_divfloat_exception(get_clients, nr_parties) -> None:
         x / y
 
 
-"""
-
-
 @pytest.mark.parametrize("nr_clients", [2, 3, 4, 5])
 @pytest.mark.parametrize("op_str", ["add", "sub", "mul", "matmul"])
 def test_ops_public_mpc(get_clients, nr_clients, op_str) -> None:
@@ -256,9 +247,6 @@ def test_ops_public_mpc(get_clients, nr_clients, op_str) -> None:
     result = op(y_secret, x).reconstruct()
 
     assert np.allclose(result, expected_result, atol=10e-4)
-
-
-"""
 
 
 @pytest.mark.parametrize("nr_clients", [2, 3, 4, 5])
@@ -316,26 +304,26 @@ def test_generate_shares() -> None:
 
     assert sum(shares_from_share_tensor).tensor == sum(shares_from_secret).tensor
 
-    x_share = ShareTensor(data=x_secret, encoder_precision=precision, encoder_base=base)
+    x_share = ShareTensor(
+        data=x_secret, config=Config(encoder_precision=precision, encoder_base=base)
+    )
 
     shares_from_share_tensor = MPCTensor.generate_shares(x_share, 2)
     shares_from_secret = MPCTensor.generate_shares(
-        x_secret, 2, encoder_precision=precision, encoder_base=base
+        x_secret, 2, config=Config(encoder_precision=precision, encoder_base=base)
     )
 
     assert sum(shares_from_share_tensor).tensor == sum(shares_from_secret).tensor
 
 
-def test_generate_shares_session(get_clients) -> None:
-    clients = get_clients(2)
-    session = Session(parties=clients)
-    SessionManager.setup_mpc(session)
-
+def test_generate_shares_config(get_clients) -> None:
     x_secret = torch.Tensor([5.0])
-    x_share = ShareTensor(data=x_secret, session=session)
+    x_share = ShareTensor(data=x_secret)
 
     shares_from_share_tensor = MPCTensor.generate_shares(x_share, 2)
-    shares_from_secret = MPCTensor.generate_shares(x_secret, 2, session=session)
+    shares_from_secret = MPCTensor.generate_shares(
+        x_secret, 2, config=Config(encoder_base=2, encoder_precision=16)
+    )
 
     assert sum(shares_from_share_tensor) == sum(shares_from_secret)
 

--- a/tests/sympc/tensor/share_tensor_test.py
+++ b/tests/sympc/tensor/share_tensor_test.py
@@ -1,5 +1,6 @@
 # stdlib
 import operator
+from uuid import uuid4
 
 # third party
 import numpy as np
@@ -22,33 +23,21 @@ def test_send_get(get_clients, precision, base) -> None:
     assert x_share == x_ptr.get()
 
 
-def test_send_get_orchestrator(get_clients) -> None:
-    client = get_clients(1)  # Testing it with session initliazed by orchestrator
-    session = Session(parties=client)
-    SessionManager.setup_mpc(session)
-    x = torch.Tensor([0.122, 1.342, 4.67])
-    x_share = ShareTensor(data=x, session=session)
+def test_different_session_ids() -> None:
+    x_share = ShareTensor(data=5, session_uuid=uuid4())
+    y_share = ShareTensor(data=5, session_uuid=uuid4())
 
-    x_ptr = x_share.send(client[0])
-
-    assert x_share == x_ptr.get()
-
-
-def test_different_session() -> None:
-    x_share = ShareTensor(data=5)
-    y_share = ShareTensor(data=5)
-
-    # Different sessions
+    # Different session ids
     assert x_share != y_share
 
 
-def test_different_tensor() -> None:
-    x_share = ShareTensor(data=5)
-    session = x_share.session
+def test_same_session_id_and_data() -> None:
 
-    y_share = ShareTensor(data=6, session=session)
+    session_id = uuid4()
+    x_share = ShareTensor(data=5, session_uuid=session_id)
+    y_share = ShareTensor(data=6, session_uuid=session_id)
 
-    # Different values for tensor
+    # Different session ids
     assert x_share != y_share
 
 


### PR DESCRIPTION
## Description
Don't use the ```session_ptr``` anymore when calling some remote methods and use the ```session_uuid```.
When the orchestrator sends the session to the other parties, it would generate a UUID for each sent session and the party would save the session locally on their side - Check this [PR](https://github.com/OpenMined/PySyft/pull/5600) in the `session_utils.py`. At this point, each party has the session.

When we want to use ```parallel_computation``` we can pass the session_uuid (is unique for each parry) or use the share_tensors which should have a `session_uuid` attached to them.

## Affected Dependencies
- How `ShareTensor`, `MPCTensor`, and `Session` are used and serialized.

## How has this been tested?
- [ ] The unit tests are passing

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
