### PR TITLE
Added security_type attribute to protocol

### DIFF
--- a/src/sympc/protocol/falcon/falcon.py
+++ b/src/sympc/protocol/falcon/falcon.py
@@ -18,6 +18,21 @@ class Falcon(metaclass=Protocol):
 
     """Used for Share Level static operations like distrubuting the shares."""
     share_class: SyMPCTensor = ReplicatedSharedTensor
+    security_levels: List[str] = ["semi-honest", "malicious"]
+
+    def __init__(self, security_type: str = "semi-honest"):
+        """Intializer for the Protocol.
+
+        Args:
+            security_type : specifies the security level of the Protocol.
+
+        Raises:
+            ValueError : If invalid security_type is provided.
+        """
+        if security_type not in self.security_levels:
+            raise ValueError(f"{security_type} is not a valid securtiy type")
+
+        self.security_type = security_type
 
     @staticmethod
     def distribute_shares(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
@@ -31,3 +46,20 @@ class Falcon(metaclass=Protocol):
             The result returned by the tensor specific distribute_shares method
         """
         return Falcon.share_class.distribute_shares(*args, **kwargs)
+
+    def __eq__(self, other: Any) -> bool:
+        """Check if "self" is equal with another object given a set of attributes to compare.
+
+        Args:
+            other (Any): Object to compare
+
+        Returns:
+            bool: True if equal False if not.
+        """
+        if not self.security_type == other.security_type:
+            return False
+
+        if not type(self).__name__ == type(other).__name__:
+            return False
+
+        return True

--- a/src/sympc/protocol/falcon/falcon.py
+++ b/src/sympc/protocol/falcon/falcon.py
@@ -16,12 +16,12 @@ from sympc.tensor.tensor import SyMPCTensor
 class Falcon(metaclass=Protocol):
     """Falcon Protocol Implementation."""
 
-    """Used for Share Level static operations like distrubuting the shares."""
+    """Used for Share Level static operations like distributing the shares."""
     share_class: SyMPCTensor = ReplicatedSharedTensor
     security_levels: List[str] = ["semi-honest", "malicious"]
 
     def __init__(self, security_type: str = "semi-honest"):
-        """Intializer for the Protocol.
+        """Initialization of the Protocol.
 
         Args:
             security_type : specifies the security level of the Protocol.
@@ -30,7 +30,7 @@ class Falcon(metaclass=Protocol):
             ValueError : If invalid security_type is provided.
         """
         if security_type not in self.security_levels:
-            raise ValueError(f"{security_type} is not a valid securtiy type")
+            raise ValueError(f"{security_type} is not a valid security type")
 
         self.security_type = security_type
 

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -183,12 +183,12 @@ def fss_op(x1: MPCTensor, x2: MPCTensor, op="eq") -> MPCTensor:
 class FSS(metaclass=Protocol):
     """Function Secret Sharing."""
 
-    """ Used for Share Level static operations like distrubuting the shares."""
+    """ Used for Share Level static operations like distributing the shares."""
     share_class: SyMPCTensor = ShareTensor
     security_levels: List[str] = ["semi-honest"]
 
     def __init__(self, security_type: str = "semi-honest"):
-        """Intializer for the Protocol.
+        """Initialization of the Protocol.
 
         Args:
             security_type : specifies the security level of the Protocol.
@@ -197,7 +197,7 @@ class FSS(metaclass=Protocol):
             ValueError : If invalid security_type is provided.
         """
         if security_type not in self.security_levels:
-            raise ValueError(f"{security_type} is not a valid securtiy type")
+            raise ValueError(f"{security_type} is not a valid security type")
 
         self.security_type = security_type
 

--- a/src/sympc/protocol/fss/fss.py
+++ b/src/sympc/protocol/fss/fss.py
@@ -185,6 +185,21 @@ class FSS(metaclass=Protocol):
 
     """ Used for Share Level static operations like distrubuting the shares."""
     share_class: SyMPCTensor = ShareTensor
+    security_levels: List[str] = ["semi-honest"]
+
+    def __init__(self, security_type: str = "semi-honest"):
+        """Intializer for the Protocol.
+
+        Args:
+            security_type : specifies the security level of the Protocol.
+
+        Raises:
+            ValueError : If invalid security_type is provided.
+        """
+        if security_type not in self.security_levels:
+            raise ValueError(f"{security_type} is not a valid securtiy type")
+
+        self.security_type = security_type
 
     @staticmethod
     def eq(x1: MPCTensor, x2: MPCTensor) -> MPCTensor:
@@ -224,6 +239,23 @@ class FSS(metaclass=Protocol):
             The result returned by the tensor specific distribute_shares method
         """
         return FSS.share_class.distribute_shares(*args, **kwargs)
+
+    def __eq__(self, other: Any) -> bool:
+        """Check if "self" is equal with another object given a set of attributes to compare.
+
+        Args:
+            other (Any): Object to compare
+
+        Returns:
+            bool: True if equal False if not.
+        """
+        if not self.security_type == other.security_type:
+            return False
+
+        if not type(self).__name__ == type(other).__name__:
+            return False
+
+        return True
 
 
 """ Register Crypto Store capabilities for FSS """

--- a/src/sympc/protocol/protocol.py
+++ b/src/sympc/protocol/protocol.py
@@ -2,7 +2,6 @@
 # stdlib
 from typing import Any
 from typing import Dict
-from typing import List
 
 
 class Protocol(type):
@@ -27,19 +26,24 @@ class Protocol(type):
 
         Raises:
             ValueError: if the protocol we want to register does not have a 'share_class' attribute
+                        if the protocol registered does not have a 'security_levels' attribute
                         if the protocol is already registered with the same name
         """
         new_cls = super().__new__(cls, name, bases, dct)
 
         if getattr(new_cls, "share_class", None) is None:
             raise ValueError(
-                "share_class attribut should be present in the protocol class"
+                "share_class attribute should be present in the protocol class"
             )
+
+        if getattr(new_cls, "security_levels", None) is None:
+            raise ValueError(
+                "security_levels attribute should be present in the protocol class."
+            )
+
+        if name in Protocol.registered_protocols.keys():
+            raise ValueError(f"{name} is already registered.")
 
         Protocol.registered_protocols[name] = new_cls
 
-        def __init__(self, *args: List[Any], **kwargs: Dict[Any, Any]) -> None:  # noqa
-            raise ValueError("Protocol class should not be instantiated")
-
-        setattr(new_cls, "__init__", __init__)
         return new_cls

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -100,7 +100,7 @@ class Session:
         parties: Optional[List[Any]] = None,
         ring_size: int = 2 ** 64,
         config: Optional[Config] = None,
-        protocol: Optional[str] = "FSS",
+        protocol: Optional[Protocol] = None,
         ttp: Optional[Any] = None,
     ) -> None:
         """Initializer for the Session.
@@ -139,10 +139,14 @@ class Session:
             Dict[Any, Any]
         ] = None  # TODO: this should be CryptoStore
 
-        if protocol not in Protocol.registered_protocols:
-            raise ValueError(f"{protocol} not registered!")
+        self.protocol: Protocol = None
+        if protocol is None:
+            self.protocol = Protocol.registered_protocols["FSS"]()
+        else:
+            if type(protocol).__name__ not in Protocol.registered_protocols:
+                raise ValueError(f"{type(protocol).__name__} not registered!")
 
-        self.protocol: Protocol = Protocol.registered_protocols[protocol]
+            self.protocol = protocol
 
         self.config = config if config else Config()
 

--- a/tests/sympc/protocol/falcon/falcon_test.py
+++ b/tests/sympc/protocol/falcon/falcon_test.py
@@ -1,3 +1,7 @@
+# third party
+# third party
+import pytest
+
 from sympc.protocol import Falcon
 from sympc.session import Session
 from sympc.tensor import ReplicatedSharedTensor
@@ -8,5 +12,11 @@ def test_share_class() -> None:
 
 
 def test_session() -> None:
-    session = Session(protocol="Falcon")
-    assert session.protocol == Falcon
+    protocol = Falcon("malicious")
+    session = Session(protocol=protocol)
+    assert type(session.protocol) == Falcon
+
+
+def test_invalid_security_type():
+    with pytest.raises(ValueError):
+        Falcon(security_type="covert")

--- a/tests/sympc/protocol/fss/fss_test.py
+++ b/tests/sympc/protocol/fss/fss_test.py
@@ -1,4 +1,5 @@
 # third party
+import pytest
 import torch
 
 from sympc.protocol import FSS
@@ -21,3 +22,8 @@ def test_share_tensor(get_clients) -> None:
     distributed_shares = FSS.distribute_shares(shares, session=session)
 
     assert all(ispointer(share_ptr) for share_ptr in distributed_shares)
+
+
+def test_invalid_security_type():
+    with pytest.raises(ValueError):
+        FSS(security_type="malicious")

--- a/tests/sympc/protocol/protocol_test.py
+++ b/tests/sympc/protocol/protocol_test.py
@@ -13,6 +13,7 @@ from sympc.tensor import ShareTensor
 
 class TestProtocol(metaclass=Protocol):
     share_class = ShareTensor
+    security_levels = ["semi-honest", "malicious", "covert"]
 
 
 def test_register_protocol() -> None:
@@ -23,8 +24,27 @@ def test_register_protocol() -> None:
 def test_exception_no_share_class() -> None:
     with pytest.raises(ValueError):
 
-        class TestProtocolException(metaclass=Protocol):
-            ...
+        class TestProtocolShareException(metaclass=Protocol):
+            security_levels = ["semi-honest"]
+
+
+def test_exception_no_security_levels() -> None:
+    with pytest.raises(ValueError):
+
+        class TestProtocolSecurityException(metaclass=Protocol):
+            share_class = ShareTensor
+
+
+def test_protocol_class_same_name() -> None:
+    class TestName(metaclass=Protocol):
+        share_class = ShareTensor
+        security_levels = ["semi-honest"]
+
+    with pytest.raises(ValueError):
+
+        class TestName(metaclass=Protocol):
+            share_class = ShareTensor
+            security_levels = ["semi-honest"]
 
 
 def test_exception_unsupported_fss_operation():

--- a/tests/sympc/tensor/mpc_tensor_test.py
+++ b/tests/sympc/tensor/mpc_tensor_test.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from sympc.config import Config
+from sympc.protocol.protocol import Protocol
 from sympc.session import Session
 from sympc.session import SessionManager
 from sympc.tensor import MPCTensor
@@ -328,7 +329,10 @@ def test_generate_shares_config(get_clients) -> None:
     assert sum(shares_from_share_tensor) == sum(shares_from_secret)
 
 
-@pytest.mark.parametrize("protocol", ["FSS"])
+fss_obj = Protocol.registered_protocols["FSS"]()
+
+
+@pytest.mark.parametrize("protocol", [fss_obj])
 @pytest.mark.parametrize("op_str", ["le", "lt", "ge", "gt"])
 def test_comparison_mpc_mpc(get_clients, protocol, op_str) -> None:
     clients = get_clients(2)
@@ -347,7 +351,7 @@ def test_comparison_mpc_mpc(get_clients, protocol, op_str) -> None:
     assert (result == expected_result).all()
 
 
-@pytest.mark.parametrize("protocol", ["FSS"])
+@pytest.mark.parametrize("protocol", [fss_obj])
 @pytest.mark.parametrize("op_str", ["eq", "ne"])
 def test_equality_mpc_mpc(get_clients, protocol, op_str) -> None:
     clients = get_clients(2)
@@ -366,7 +370,7 @@ def test_equality_mpc_mpc(get_clients, protocol, op_str) -> None:
     assert (result == expected_result).all()
 
 
-@pytest.mark.parametrize("protocol", ["FSS"])
+@pytest.mark.parametrize("protocol", [fss_obj])
 @pytest.mark.parametrize("op_str", ["le", "lt", "ge", "gt", "eq", "ne"])
 def test_comp_mpc_public(get_clients, protocol, op_str) -> None:
     clients = get_clients(2)
@@ -384,7 +388,7 @@ def test_comp_mpc_public(get_clients, protocol, op_str) -> None:
     assert (result == expected_result).all()
 
 
-@pytest.mark.parametrize("protocol", ["FSS"])
+@pytest.mark.parametrize("protocol", [fss_obj])
 @pytest.mark.parametrize("op_str", ["le", "lt", "ge", "gt", "eq", "ne"])
 def test_comp_public_mpc(get_clients, protocol, op_str) -> None:
     clients = get_clients(2)

--- a/tests/sympc/tensor/mpc_tensor_test.py
+++ b/tests/sympc/tensor/mpc_tensor_test.py
@@ -329,10 +329,10 @@ def test_generate_shares_config(get_clients) -> None:
     assert sum(shares_from_share_tensor) == sum(shares_from_secret)
 
 
-fss_obj = Protocol.registered_protocols["FSS"]()
+fss_protocol = Protocol.registered_protocols["FSS"]()
 
 
-@pytest.mark.parametrize("protocol", [fss_obj])
+@pytest.mark.parametrize("protocol", [fss_protocol])
 @pytest.mark.parametrize("op_str", ["le", "lt", "ge", "gt"])
 def test_comparison_mpc_mpc(get_clients, protocol, op_str) -> None:
     clients = get_clients(2)
@@ -351,7 +351,7 @@ def test_comparison_mpc_mpc(get_clients, protocol, op_str) -> None:
     assert (result == expected_result).all()
 
 
-@pytest.mark.parametrize("protocol", [fss_obj])
+@pytest.mark.parametrize("protocol", [fss_protocol])
 @pytest.mark.parametrize("op_str", ["eq", "ne"])
 def test_equality_mpc_mpc(get_clients, protocol, op_str) -> None:
     clients = get_clients(2)
@@ -370,7 +370,7 @@ def test_equality_mpc_mpc(get_clients, protocol, op_str) -> None:
     assert (result == expected_result).all()
 
 
-@pytest.mark.parametrize("protocol", [fss_obj])
+@pytest.mark.parametrize("protocol", [fss_protocol])
 @pytest.mark.parametrize("op_str", ["le", "lt", "ge", "gt", "eq", "ne"])
 def test_comp_mpc_public(get_clients, protocol, op_str) -> None:
     clients = get_clients(2)
@@ -388,7 +388,7 @@ def test_comp_mpc_public(get_clients, protocol, op_str) -> None:
     assert (result == expected_result).all()
 
 
-@pytest.mark.parametrize("protocol", [fss_obj])
+@pytest.mark.parametrize("protocol", [fss_protocol])
 @pytest.mark.parametrize("op_str", ["le", "lt", "ge", "gt", "eq", "ne"])
 def test_comp_public_mpc(get_clients, protocol, op_str) -> None:
     clients = get_clients(2)

--- a/tests/sympc/tensor/replicatedshare_tensor_test.py
+++ b/tests/sympc/tensor/replicatedshare_tensor_test.py
@@ -58,7 +58,6 @@ def test_different_config() -> None:
     assert x_share != y_share
 
 
-# @pytest.mark.skip(reason="Will be added after RSTensor Proto")
 def test_send_get(get_clients, precision=12, base=4) -> None:
 
     client = get_clients(1)[0]


### PR DESCRIPTION
## Description
This PR adds security_type attribute to the MPC protocols,given that each protocol has different security guarantees.It fixes #219 .
Corresponding PR in [PySyft](https://github.com/OpenMined/PySyft/pull/5640) for serialization and de serialization of Protocol class

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
Added tests for the same.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
