### PR TITLE
Add `len` method for `MPCTensor`

### DIFF
--- a/src/sympc/tensor/mpc_tensor.py
+++ b/src/sympc/tensor/mpc_tensor.py
@@ -789,6 +789,14 @@ class MPCTensor(metaclass=SyMPCTensor):
 
         return result
 
+    def __len__(self) -> int:
+        """Return the length of MPCTensor.
+
+        Returns:
+            int: Length
+        """
+        return self.shape[0]
+
     def __str__(self) -> str:
         """Return the string representation of MPCTensor.
 

--- a/tests/sympc/tensor/mpc_tensor_test.py
+++ b/tests/sympc/tensor/mpc_tensor_test.py
@@ -269,6 +269,17 @@ def test_ops_integer(get_clients, nr_clients, op_str) -> None:
     assert np.allclose(result, expected_result, atol=10e-3)
 
 
+def test_mpc_len(get_clients) -> None:
+    clients = get_clients(2)
+    session = Session(parties=clients)
+    SessionManager.setup_mpc(session)
+
+    for dim in range(1, 5):
+        x_secret = torch.arange(-6, 6).view(dim, -1)
+        x = MPCTensor(secret=x_secret, session=session)
+        assert len(x_secret) == len(x)
+
+
 def test_mpc_print(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)


### PR DESCRIPTION
## Description
Closes #182

I think that should be it :stuck_out_tongue:

## Affected Dependencies
None.

## How has this been tested?
- Added a test

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
