### PR TITLE
Custom value for pytest workers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ --deselect=tests/notebooks -n auto
+          pytest tests/ --deselect=tests/notebooks -n 8
 
       - name: Run codecov
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ --deselect=tests/notebooks -n 8
+          pytest tests/ --deselect=tests/notebooks -n 8 -x
 
       - name: Run codecov
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 9
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -13,8 +13,9 @@ notebook==6.2.0
 papermill==2.3.1
 pep8-naming==0.11.1
 pre-commit==2.11.1
-pytest==6.2.2
+pytest==6.2.4
 pytest-benchmark==3.4.1
 pytest-cov==2.10.1
+pytest-order==1.0.0
 pytest-xdist[psutil]
 safety

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,14 +9,13 @@ from typing import List
 import pytest
 import syft as sy
 
-vms = [sy.VirtualMachine(name=f"P_{i}") for i in range(11)]
-
 
 @pytest.fixture
 def get_clients() -> Callable[[int], List[Any]]:
     def _helper_get_clients(nr_clients: int) -> List[Any]:
-        shared_vms = [vm for vm in vms[0:nr_clients]]
-        clients = [vm.get_root_client() for vm in shared_vms]
-        return clients
+        return [
+            sy.VirtualMachine(name=f"P_{i}").get_root_client()
+            for i in range(nr_clients)
+        ]
 
     return _helper_get_clients

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,6 @@ vms = [sy.VirtualMachine(name=f"P_{i}") for i in range(11)]
 def get_clients() -> Callable[[int], List[Any]]:
     def _helper_get_clients(nr_clients: int) -> List[Any]:
         shared_vms = [vm for vm in vms[0:nr_clients]]
-        for i in shared_vms:
-            i.store.clear()
         clients = [vm.get_root_client() for vm in shared_vms]
         return clients
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Configuration file to share fixtures across benchmarks."""
+
 # stdlib
 from typing import Any
 from typing import Callable
@@ -7,13 +9,16 @@ from typing import List
 import pytest
 import syft as sy
 
+vms = [sy.VirtualMachine(name=f"P_{i}") for i in range(11)]
+
 
 @pytest.fixture
 def get_clients() -> Callable[[int], List[Any]]:
     def _helper_get_clients(nr_clients: int) -> List[Any]:
-        return [
-            sy.VirtualMachine(name=f"P_{i}").get_root_client()
-            for i in range(nr_clients)
-        ]
+        shared_vms = [vm for vm in vms[0:nr_clients]]
+        for i in shared_vms:
+            i.store.clear()
+        clients = [vm.get_root_client() for vm in shared_vms]
+        return clients
 
     return _helper_get_clients

--- a/tests/sympc/approximations/softmax_test.py
+++ b/tests/sympc/approximations/softmax_test.py
@@ -10,6 +10,7 @@ from sympc.session import SessionManager
 from sympc.tensor.mpc_tensor import MPCTensor
 
 
+@pytest.mark.order(7)
 @pytest.mark.parametrize(
     "dim",
     [None, -2, -1, 0, 1],
@@ -42,6 +43,7 @@ def test_softmax_single_along_dim(get_clients) -> None:
     assert torch.allclose(x_secret_softmax, x_softmax.reconstruct(), atol=1e-2)
 
 
+@pytest.mark.order(8)
 @pytest.mark.parametrize(
     "dim",
     [None, -2, -1, 0, 1],

--- a/tests/sympc/module/module_test.py
+++ b/tests/sympc/module/module_test.py
@@ -88,6 +88,7 @@ def test_exception_conv2d_kernel_mismatch(get_clients):
         model.share(session=session)
 
 
+@pytest.mark.order(1)
 def test_run_conv_model(get_clients: Callable[[int], List[Any]]):
     model = ConvNet(torch)
 

--- a/tests/sympc/module/nn/functional_test.py
+++ b/tests/sympc/module/nn/functional_test.py
@@ -24,6 +24,7 @@ def test_relu(get_clients) -> None:
     assert all(res.reconstruct() == res_expected)
 
 
+@pytest.mark.order(2)
 @pytest.mark.parametrize("reduction", ["sum", "mean"])
 def test_mse_loss(get_clients, reduction) -> None:
     clients = get_clients(4)

--- a/tests/sympc/tensor/static_test.py
+++ b/tests/sympc/tensor/static_test.py
@@ -12,6 +12,7 @@ from sympc.tensor.static import cat
 from sympc.tensor.static import stack
 
 
+@pytest.mark.order(3)
 def test_argmax_multiple_max(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)
@@ -39,6 +40,7 @@ def test_argmax(get_clients) -> None:
     assert res == expected, f"Expected argmax to be {expected}"
 
 
+@pytest.mark.order(4)
 @pytest.mark.parametrize("dim, keepdim", itertools.product([0, 1, 2], [True, False]))
 def test_argmax_dim(dim, keepdim, get_clients) -> None:
     clients = get_clients(2)
@@ -56,6 +58,7 @@ def test_argmax_dim(dim, keepdim, get_clients) -> None:
     assert (res == expected).all(), f"Expected argmax to be {expected}"
 
 
+@pytest.mark.order(5)
 def test_max_multiple_max(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)
@@ -83,6 +86,7 @@ def test_max(get_clients) -> None:
     assert res == expected, f"Expected argmax to be {expected}"
 
 
+@pytest.mark.order(6)
 @pytest.mark.parametrize("dim, keepdim", itertools.product([0, 1, 2], [True, False]))
 def test_max_dim(dim, keepdim, get_clients) -> None:
     clients = get_clients(2)


### PR DESCRIPTION
## Description
Currently our CI takes a lot to time execute , setting a custom number of  workers of pytest instead of `pytest -n auto` greatly reduced the CI time.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
CI time duration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
