### PR TITLE
Initialization of  Default Protocol class

### DIFF
--- a/src/sympc/api.py
+++ b/src/sympc/api.py
@@ -30,6 +30,8 @@ allowed_external_modules = [
     ("sympc.tensor.static", tensor.static),
     ("sympc.protocol", protocol),
     ("sympc.store", store),
+    ("sympc.protocol.default", protocol.default),
+    ("sympc.protocol.default.default", protocol.default.default),
     ("sympc.protocol.falcon", protocol.falcon),
     ("sympc.protocol.falcon.falcon", protocol.falcon.falcon),
     ("sympc.protocol.fss", protocol.fss),

--- a/src/sympc/protocol/__init__.py
+++ b/src/sympc/protocol/__init__.py
@@ -1,8 +1,9 @@
 """Implemented Protocols."""
 from . import beaver
 from . import spdz
+from .default import DefaultProtocol
 from .falcon import Falcon
 from .fss import FSS
 from .protocol import Protocol
 
-__all__ = ["beaver", "spdz", "Falcon", "FSS", "Protocol"]
+__all__ = ["beaver", "spdz", "Falcon", "FSS", "DefaultProtocol", "Protocol"]

--- a/src/sympc/protocol/default/__init__.py
+++ b/src/sympc/protocol/default/__init__.py
@@ -1,0 +1,5 @@
+"""Default Protocol."""
+
+from .default import DefaultProtocol
+
+__all__ = ["DefaultProtocol"]

--- a/src/sympc/protocol/default/default.py
+++ b/src/sympc/protocol/default/default.py
@@ -1,0 +1,62 @@
+"""Default Protocol."""
+
+# stdlib
+from typing import Any
+from typing import Dict
+from typing import List
+
+from sympc.protocol.protocol import Protocol
+from sympc.tensor import ReplicatedSharedTensor
+from sympc.tensor.tensor import SyMPCTensor
+
+
+class DefaultProtocol(metaclass=Protocol):
+    """Default Protocol Implementation."""
+
+    """Used for Share Level static operations like distributing the shares."""
+    share_class: SyMPCTensor = ReplicatedSharedTensor
+    security_levels: List[str] = ["semi-honest", "malicious"]
+
+    def __init__(self, security_type: str = "semi-honest"):
+        """Initialization of the Protocol.
+
+        Args:
+            security_type : specifies the security level of the Protocol.
+
+        Raises:
+            ValueError : If invalid security_type is provided.
+        """
+        if security_type not in self.security_levels:
+            raise ValueError(f"{security_type} is not a valid security type")
+
+        self.security_type = security_type
+
+    @staticmethod
+    def distribute_shares(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
+        """Forward the call to the tensor specific class.
+
+        Args:
+            *args (List[Any]): list of args to be forwarded
+            **kwargs(Dict[str, Any): list of named args to be forwarded
+
+        Returns:
+            The result returned by the tensor specific distribute_shares method
+        """
+        return DefaultProtocol.share_class.distribute_shares(*args, **kwargs)
+
+    def __eq__(self, other: Any) -> bool:
+        """Check if "self" is equal with another object given a set of attributes to compare.
+
+        Args:
+            other (Any): Object to compare
+
+        Returns:
+            bool: True if equal False if not.
+        """
+        if not self.security_type == other.security_type:
+            return False
+
+        if not type(self).__name__ == type(other).__name__:
+            return False
+
+        return True

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -163,7 +163,7 @@ class Session:
         self.tensor_type: Union[torch.dtype] = get_type_from_ring(ring_size)
         self.ring_size = ring_size
         self.min_value = -(ring_size) // 2
-        self.max_value = (ring_size - 1) // 2
+        self.max_value = (ring_size) // 2 - 1
 
         self.autograd_active = False
 

--- a/src/sympc/session/session.py
+++ b/src/sympc/session/session.py
@@ -148,16 +148,6 @@ class Session:
 
             self.protocol = protocol
 
-        if (
-            self.parties
-            and len(self.parties) < 3
-            and self.protocol.security_type == "malicious"
-        ):
-
-            raise ValueError(
-                "Malicious security cannot be provided to less than 3 parties"
-            )
-
         self.config = config if config else Config()
 
         self.przs_generators: List[Optional[torch.Generator]] = []

--- a/src/sympc/session/session_manager.py
+++ b/src/sympc/session/session_manager.py
@@ -29,9 +29,9 @@ class SessionManager:
         """Initializer for the Session Manager.
 
         Raises:
-            NotImplementedError: This class it is not supposed to be instanciated.
+            NotImplementedError: This class it is not supposed to be instantiated.
         """
-        raise NotImplementedError("This is not suposed to be instanciated!")
+        raise NotImplementedError("This is not supposed to be instantiated!")
 
     @staticmethod
     def setup_mpc(session: Session) -> None:
@@ -42,7 +42,13 @@ class SessionManager:
 
         Args:
             session (Session): Session to send.
+
+        Raises:
+            ValueError : If the specified protocol is falcon and parties!=3
         """
+        if type(session.protocol).__name__ == "Falcon" and session.nr_parties != 3:
+            raise ValueError("Falcon is a 3 Party Computation Protocol")
+
         uuids: Dict[int, UUID] = {}
         for rank, party in enumerate(session.parties):
             # Assign a new rank before sending it to another party

--- a/tests/sympc/protocol/default/default_test.py
+++ b/tests/sympc/protocol/default/default_test.py
@@ -1,0 +1,13 @@
+from sympc.protocol import DefaultProtocol
+from sympc.session import Session
+from sympc.tensor import ReplicatedSharedTensor
+
+
+def test_share_class() -> None:
+    assert DefaultProtocol.share_class == ReplicatedSharedTensor
+
+
+def test_session() -> None:
+    defaultprotocol = DefaultProtocol()
+    session = Session(protocol=defaultprotocol)
+    assert type(session.protocol) == DefaultProtocol

--- a/tests/sympc/protocol/default/default_test.py
+++ b/tests/sympc/protocol/default/default_test.py
@@ -1,4 +1,8 @@
+# third party
+import pytest
+
 from sympc.protocol import DefaultProtocol
+from sympc.protocol import Falcon
 from sympc.session import Session
 from sympc.tensor import ReplicatedSharedTensor
 
@@ -11,3 +15,24 @@ def test_session() -> None:
     defaultprotocol = DefaultProtocol()
     session = Session(protocol=defaultprotocol)
     assert type(session.protocol) == DefaultProtocol
+
+
+def test_invalid_security_type():
+    with pytest.raises(ValueError):
+        DefaultProtocol(security_type="covert")
+
+
+def test_eq():
+    default = DefaultProtocol()
+    falcon1 = Falcon(security_type="malicious")
+    falcon2 = Falcon()
+    other2 = default
+
+    # Test equal protocol:
+    assert default == other2
+
+    # Test different protocol security type
+    assert default != falcon1
+
+    # Test different protocol objects
+    assert default != falcon2

--- a/tests/sympc/protocol/falcon/falcon_test.py
+++ b/tests/sympc/protocol/falcon/falcon_test.py
@@ -1,6 +1,7 @@
 # third party
 import pytest
 
+from sympc.protocol import DefaultProtocol
 from sympc.protocol import Falcon
 from sympc.session import Session
 from sympc.tensor import ReplicatedSharedTensor
@@ -16,13 +17,22 @@ def test_session() -> None:
     assert type(session.protocol) == Falcon
 
 
-def test_exception_malicious_less_parties(get_clients, parties=2) -> None:
-    parties = get_clients(parties)
-    protocol = Falcon("malicious")
-    with pytest.raises(ValueError):
-        Session(protocol=protocol, parties=parties)
-
-
 def test_invalid_security_type():
     with pytest.raises(ValueError):
         Falcon(security_type="covert")
+
+
+def test_eq():
+    falcon = Falcon()
+    default1 = DefaultProtocol(security_type="malicious")
+    default2 = DefaultProtocol()
+    other2 = falcon
+
+    # Test equal protocol:
+    assert falcon == other2
+
+    # Test different protocol security type
+    assert falcon != default1
+
+    # Test different protocol objects
+    assert falcon != default2

--- a/tests/sympc/session/session_manager_test.py
+++ b/tests/sympc/session/session_manager_test.py
@@ -6,6 +6,7 @@ from uuid import UUID
 # third party
 import pytest
 
+from sympc.protocol import Falcon
 from sympc.session import Session
 from sympc.session import SessionManager
 
@@ -25,3 +26,12 @@ def test_setup_mpc(get_clients):
     assert isinstance(session.uuid, UUID)
     assert list(session.rank_to_uuid.keys()) == [0, 1]
     assert all(isinstance(e, UUID) for e in session.rank_to_uuid.values())
+
+
+@pytest.mark.parametrize("parties", [2, 4, 5, 6])
+def test_exception_parties_count(get_clients, parties) -> None:
+    parties = get_clients(parties)
+    protocol = Falcon("malicious")
+    with pytest.raises(ValueError):
+        session = Session(protocol=protocol, parties=parties)
+        SessionManager.setup_mpc(session)

--- a/tests/sympc/session/session_test.py
+++ b/tests/sympc/session/session_test.py
@@ -31,7 +31,7 @@ def test_session_default_init() -> None:
     assert session.tensor_type == get_type_from_ring(2 ** 64)
     assert session.ring_size == 2 ** 64
     assert session.min_value == -(2 ** 64) // 2
-    assert session.max_value == (2 ** 64 - 1) // 2
+    assert session.max_value == (2 ** 64) // 2 - 1
 
 
 def test_session_custom_init() -> None:
@@ -55,7 +55,7 @@ def test_session_custom_init() -> None:
     assert session.tensor_type == get_type_from_ring(2 ** 32)
     assert session.ring_size == 2 ** 32
     assert session.min_value == -(2 ** 32) // 2
-    assert session.max_value == (2 ** 32 - 1) // 2
+    assert session.max_value == (2 ** 32) // 2 - 1
     assert type(session.get_protocol()).__name__ == "Falcon"
 
 
@@ -103,11 +103,11 @@ def test_copy() -> None:
 
 
 def test_invalid_protocol_exception() -> None:
-    class TestProtocol:
+    class TestProtocolInvalid:
         pass
 
     with pytest.raises(ValueError):
-        Session(protocol=TestProtocol())
+        Session(protocol=TestProtocolInvalid())
 
 
 def test_invalid_ringsize_exception() -> None:


### PR DESCRIPTION
## Description
Initialization of the Default Protocol class.The default protocol will contain all the primtive operations.In a session if a given protocol does not implement a specific operation.It would be reverted to the Default Protocol class.

## Affected Dependencies
Since Falcon is 3PC,Adding DefaultProtocol would make RSTensor framework agnostic

## How has this been tested?
Added tests for the same.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
