### PR TITLE
Remove deprecated syft.load

### DIFF
--- a/src/sympc/__init__.py
+++ b/src/sympc/__init__.py
@@ -25,7 +25,6 @@ try:
     # third party
     import syft
 
-    syft.load("sympc")
 except ImportError as e:
     print("PySyft is needed to be able to use SyMPC")
     raise e


### PR DESCRIPTION
## Description
`dev` version of `syft` has removed the manual `syft.load()`, appearing a deprecated message.
This PR removes this line of code from `sympc` 

Close #239 

## Affected Dependencies
None

## How has this been tested?
Tests run as expected

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
