### PR TITLE
Modified allowlist to use absolute paths.

### DIFF
--- a/src/sympc/api.py
+++ b/src/sympc/api.py
@@ -32,6 +32,8 @@ allowed_external_modules = [
     ("sympc", sympc),
     ("sympc.session", session),
     ("sympc.tensor", tensor),
+    ("sympc.tensor.share_tensor", tensor.share_tensor),
+    ("sympc.tensor.replicatedshare_tensor", tensor.replicatedshare_tensor),
     ("sympc.tensor.static", tensor.static),
     ("sympc.protocol", protocol),
     ("sympc.module", module),
@@ -52,175 +54,210 @@ allowed_external_classes = [
     ("sympc.session.Session", "sympc.session.Session", session.Session),
     ("sympc.store.CryptoStore", "sympc.store.CryptoStore", store.CryptoStore),
     (
-        "sympc.tensor.ShareTensor",
-        "sympc.tensor.ShareTensor",
-        tensor.ShareTensor,
+        "sympc.tensor.share_tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor",
+        tensor.share_tensor.ShareTensor,
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor",
-        "sympc.tensor.ReplicatedSharedTensor",
-        tensor.ReplicatedSharedTensor,
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
+        tensor.replicatedshare_tensor.ReplicatedSharedTensor,
     ),
 ]
 
 share_tensor_attrs = [
     (
-        "sympc.tensor.ShareTensor.__add__",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.__add__",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.__sub__",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.__sub__",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.__rmul__",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.__rmul__",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.__mul__",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.__mul__",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.__matmul__",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.__matmul__",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.__truediv__",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.__truediv__",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.__rmatmul__",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.__rmatmul__",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.t",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.t",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.sum",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.sum",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.clone",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.clone",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     (
-        "sympc.tensor.ShareTensor.numel",
+        "sympc.tensor.share_tensor.ShareTensor.numel",
         "syft.lib.python.Int",  # FIXME: Can't we just return an int??
     ),
     (
-        "sympc.tensor.ShareTensor.T",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor.T",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
-    ("sympc.tensor.ShareTensor.squeeze", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.ShareTensor.unsqueeze", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.ShareTensor.reshape", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.ShareTensor.view", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.static.stack_share_tensor", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.static.cat_share_tensor", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.static.helper_argmax_pairwise", "sympc.tensor.ShareTensor"),
+    (
+        "sympc.tensor.share_tensor.ShareTensor.squeeze",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
+    (
+        "sympc.tensor.share_tensor.ShareTensor.unsqueeze",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
+    (
+        "sympc.tensor.share_tensor.ShareTensor.reshape",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
+    (
+        "sympc.tensor.share_tensor.ShareTensor.view",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
+    ("sympc.tensor.static.stack_share_tensor", "sympc.tensor.share_tensor.ShareTensor"),
+    ("sympc.tensor.static.cat_share_tensor", "sympc.tensor.share_tensor.ShareTensor"),
+    (
+        "sympc.tensor.static.helper_argmax_pairwise",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
     (
         "sympc.module.nn.functional.helper_max_pool2d_reshape",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
-    ("sympc.tensor.ShareTensor.shape", "syft.lib.python.Tuple"),
+    ("sympc.tensor.share_tensor.ShareTensor.shape", "syft.lib.python.Tuple"),
+    (
+        "sympc.tensor.share_tensor.ShareTensor.repeat",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
+    (
+        "sympc.tensor.share_tensor.ShareTensor.narrow",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
+    ("sympc.tensor.share_tensor.ShareTensor.dim", "syft.lib.python.Int"),
+    (
+        "sympc.tensor.share_tensor.ShareTensor.transpose",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
+    (
+        "sympc.tensor.share_tensor.ShareTensor.flatten",
+        "sympc.tensor.share_tensor.ShareTensor",
+    ),
 ]
 
 replicated_shared_tensor_attrs = [
     (
-        "sympc.tensor.ReplicatedSharedTensor.__add__",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__add__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.__sub__",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__sub__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.__rmul__",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__rmul__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.__mul__",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__mul__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.__matmul__",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__matmul__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.__truediv__",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__truediv__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.__rmatmul__",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__rmatmul__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.__setitem__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__setitem__",
         "syft.lib.python._SyNone",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.__getitem__",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.__getitem__",
         "torch.Tensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.t",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.t",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.sum",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.sum",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.clone",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.clone",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
-    ("sympc.tensor.ReplicatedSharedTensor.get_shares", "syft.lib.python.List"),
     (
-        "sympc.tensor.ReplicatedSharedTensor.numel",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.get_shares",
+        "syft.lib.python.List",
+    ),
+    (
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.numel",
         "syft.lib.python.Int",  # FIXME: Can't we just return an int??
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.T",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.T",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.ReplicatedSharedTensor.unsqueeze",
-        "sympc.tensor.ReplicatedSharedTensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.unsqueeze",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
-    ("sympc.tensor.ReplicatedSharedTensor.view", "sympc.tensor.ReplicatedSharedTensor"),
-    ("sympc.tensor.ShareTensor.repeat", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.ShareTensor.narrow", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.ShareTensor.dim", "syft.lib.python.Int"),
-    ("sympc.tensor.ShareTensor.transpose", "sympc.tensor.ShareTensor"),
-    ("sympc.tensor.ShareTensor.flatten", "sympc.tensor.ShareTensor"),
+    (
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.view",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
+    ),
 ]
 
 allowed_external_attrs = [
     (
         "sympc.module.nn.functional.max_pool2d_backward_helper",
-        "sympc.tensor.ShareTensor",
+        "sympc.tensor.share_tensor.ShareTensor",
     ),
     ("sympc.store.CryptoStore.get_primitives_from_store", "syft.lib.python.List"),
     ("sympc.store.CryptoStore.store", "syft.lib.python.Dict"),
     ("sympc.session.Session.crypto_store", "sympc.store.CryptoStore"),
     ("sympc.session.Session.init_generators", "syft.lib.python._SyNone"),
     ("sympc.session.Session.przs_generators", "syft.lib.python.List"),
-    ("sympc.protocol.fss.fss.mask_builder", "sympc.tensor.ShareTensor"),
-    ("sympc.protocol.fss.fss.evaluate", "sympc.tensor.ShareTensor"),
-    ("sympc.protocol.spdz.spdz.mul_parties", "sympc.tensor.ShareTensor"),
+    ("sympc.protocol.fss.fss.mask_builder", "sympc.tensor.share_tensor.ShareTensor"),
+    ("sympc.protocol.fss.fss.evaluate", "sympc.tensor.share_tensor.ShareTensor"),
+    ("sympc.protocol.spdz.spdz.mul_parties", "sympc.tensor.share_tensor.ShareTensor"),
     ("sympc.protocol.spdz.spdz.spdz_mask", "syft.lib.python.Tuple"),
-    ("sympc.protocol.spdz.spdz.div_wraps", "sympc.tensor.ShareTensor"),
+    ("sympc.protocol.spdz.spdz.div_wraps", "sympc.tensor.share_tensor.ShareTensor"),
     (
         "sympc.session.Session.przs_generate_random_share",
         sy.lib.misc.union.UnionGenerator[
-            "sympc.tensor.ReplicatedSharedTensor", "sympc.tensor.ShareTensor"
+            "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
+            "sympc.tensor.share_tensor.ShareTensor",
         ],
     ),
     (
         "sympc.session.Session.prrs_generate_random_share",
         sy.lib.misc.union.UnionGenerator[
-            "sympc.tensor.ReplicatedSharedTensor", "sympc.tensor.ShareTensor"
+            "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
+            "sympc.tensor.share_tensor.ShareTensor",
         ],
     ),
     (

--- a/src/sympc/api.py
+++ b/src/sympc/api.py
@@ -248,7 +248,6 @@ allowed_external_attrs = [
     ("sympc.protocol.spdz.spdz.spdz_mask", "syft.lib.python.Tuple"),
     ("sympc.protocol.spdz.spdz.div_wraps", "sympc.tensor.share_tensor.ShareTensor"),
     ("sympc.protocol.falcon.falcon.Falcon.compute_zvalue_and_add_mask", "torch.Tensor"),
-
     (
         "sympc.session.Session.przs_generate_random_share",
         sy.lib.misc.union.UnionGenerator[

--- a/src/sympc/encoder/__init__.py
+++ b/src/sympc/encoder/__init__.py
@@ -1,10 +1,9 @@
-"""Export the encoders that are currently implemented. For the moment, there is
-only:
+"""Export the encoders that are currently implemented.
 
+For the moment, there is only:
 - FixedPointEncoder: convert a float precision value
-   to a fixed precision one
+  to a fixed precision one
 """
-
 
 from .fp_encoder import FixedPointEncoder
 

--- a/src/sympc/protocol/fss/__init__.py
+++ b/src/sympc/protocol/fss/__init__.py
@@ -1,3 +1,5 @@
+"""FSS Protocol."""
+
 from .fss import FSS
 
 __all__ = ["FSS"]

--- a/tests/sympc/session/session_test.py
+++ b/tests/sympc/session/session_test.py
@@ -247,3 +247,53 @@ def test_invalid_protocol_exception() -> None:
 def test_invalid_ringsize_exception() -> None:
     with pytest.raises(ValueError):
         Session(ring_size=2 ** 63)
+
+
+def test_przs_share_tensor_union_resolve(get_clients) -> None:
+    clients = get_clients(3)
+    session = Session(parties=clients)
+    SessionManager.setup_mpc(session)
+
+    share_pt0 = session.session_ptrs[0].przs_generate_random_share(shape=(1, 2))
+    resolved_share_pt0 = share_pt0.resolve_pointer_type()
+    share_pt_name = type(resolved_share_pt0).__name__
+
+    assert share_pt_name == "ShareTensorPointer"
+
+
+def test_prrs_share_tensor_union_resolve(get_clients) -> None:
+    clients = get_clients(3)
+    session = Session(parties=clients)
+    SessionManager.setup_mpc(session)
+
+    share_pt0 = session.session_ptrs[0].prrs_generate_random_share(shape=(1, 2))
+    resolved_share_pt0 = share_pt0.resolve_pointer_type()
+    share_pt_name = type(resolved_share_pt0).__name__
+
+    assert share_pt_name == "ShareTensorPointer"
+
+
+def test_przs_rst_union_resolve(get_clients) -> None:
+    clients = get_clients(3)
+    protocol = Falcon("semi-honest")
+    session = Session(protocol=protocol, parties=clients)
+    SessionManager.setup_mpc(session)
+
+    share_pt0 = session.session_ptrs[0].przs_generate_random_share(shape=(1, 2))
+    resolved_share_pt0 = share_pt0.resolve_pointer_type()
+    share_pt_name = type(resolved_share_pt0).__name__
+
+    assert share_pt_name == "ReplicatedSharedTensorPointer"
+
+
+def test_prrs_rst_union_resolve(get_clients) -> None:
+    clients = get_clients(3)
+    protocol = Falcon("semi-honest")
+    session = Session(protocol=protocol, parties=clients)
+    SessionManager.setup_mpc(session)
+
+    share_pt0 = session.session_ptrs[0].prrs_generate_random_share(shape=(1, 2))
+    resolved_share_pt0 = share_pt0.resolve_pointer_type()
+    share_pt_name = type(resolved_share_pt0).__name__
+
+    assert share_pt_name == "ReplicatedSharedTensorPointer"

--- a/tests/sympc/tensor/replicatedshare_tensor_test.py
+++ b/tests/sympc/tensor/replicatedshare_tensor_test.py
@@ -270,6 +270,7 @@ def test_ops_share_public(op_str, precision, base) -> None:
 
     assert np.allclose(tensor_decoded, expected_res, rtol=base ** -precision)
 
+
 def test_rst_resolve_pointer(get_clients) -> None:
     clients = get_clients(3)
     protocol = Falcon("semi-honest")
@@ -283,6 +284,7 @@ def test_rst_resolve_pointer(get_clients) -> None:
     share_pt_name = type(resolved_share_pt0).__name__
 
     assert share_pt_name == "ReplicatedSharedTensorPointer"
+
 
 @pytest.mark.parametrize("parties", [3, 5, 7])
 @pytest.mark.parametrize("security", ["malicious", "semi-honest"])

--- a/tests/sympc/tensor/replicatedshare_tensor_test.py
+++ b/tests/sympc/tensor/replicatedshare_tensor_test.py
@@ -247,3 +247,18 @@ def test_ops_share_public(op_str, precision, base) -> None:
     tensor_decoded = res.fp_encoder.decode(res.shares[0])
 
     assert np.allclose(tensor_decoded, expected_res, rtol=base ** -precision)
+
+
+def test_rst_resolve_pointer(get_clients) -> None:
+    clients = get_clients(3)
+    protocol = Falcon("semi-honest")
+    session = Session(protocol=protocol, parties=clients)
+    SessionManager.setup_mpc(session)
+    secret = torch.randn(1, 2)
+    tensor = MPCTensor(secret=secret, session=session)
+
+    share_pt0 = tensor.share_ptrs[0]
+    resolved_share_pt0 = share_pt0.resolve_pointer_type()
+    share_pt_name = type(resolved_share_pt0).__name__
+
+    assert share_pt_name == "ReplicatedSharedTensorPointer"

--- a/tests/sympc/tensor/share_tensor_test.py
+++ b/tests/sympc/tensor/share_tensor_test.py
@@ -8,6 +8,9 @@ import pytest
 import torch
 
 from sympc.config import Config
+from sympc.session import Session
+from sympc.session import SessionManager
+from sympc.tensor import MPCTensor
 from sympc.tensor import ShareTensor
 
 
@@ -219,3 +222,17 @@ def test_share_decode() -> None:
     x_share = ShareTensor(data=x)
 
     assert x == x_share.decode()
+
+
+def test_share_tensor_resolve_pointer(get_clients) -> None:
+    clients = get_clients(3)
+    session = Session(parties=clients)
+    SessionManager.setup_mpc(session)
+    secret = torch.randn(1, 2)
+    tensor = MPCTensor(secret=secret, session=session)
+
+    share_pt0 = tensor.share_ptrs[0]
+    resolved_share_pt0 = share_pt0.resolve_pointer_type()
+    share_pt_name = type(resolved_share_pt0).__name__
+
+    assert share_pt_name == "ShareTensorPointer"


### PR DESCRIPTION
## Description
In our current [allowlist](https://github.com/OpenMined/SyMPC/blob/main/src/sympc/api.py), we use relative path for building the ast,methods in Pysyft use the absolute path, for ex: `ShareTensor.__module__`

Pysyft ast query:

https://github.com/OpenMined/PySyft/blob/b76c770f0e8704b9744806122ccb62af504186fa/packages/syft/src/syft/ast/klass.py#L70

We modify our current ast to use absolute paths.
This would allow us to `resolve_pointer_type` on pointer ,which validates and returns a new pointer of the underlying type,which is very much useful for `Union` and `Any` pointers.

## Affected Dependencies
Current SyMPC AST Structure.

## How has this been tested?
Added test for the same.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
