### PR TITLE
Fix the crypto provider generation for FSS

### DIFF
--- a/src/sympc/store/crypto_primitive_provider.py
+++ b/src/sympc/store/crypto_primitive_provider.py
@@ -54,6 +54,9 @@ class CryptoPrimitiveProvider:
         for remote_session_uuid, primitive in zip(
             session.rank_to_uuid.values(), primitives
         ):
+            if not isinstance(primitive, (list, tuple)):
+                primitive = (primitive,)
+
             for share in itertools.chain(*primitive):
                 share.session_uuid = remote_session_uuid
 


### PR DESCRIPTION
## Description
For FSS key generation, the `primitive` is not a tuple but a tensor. Hence, the `itertools.chain(*primitive)` iterates _through_ the tensor which doesn't make sense (but didn't fail for some reason). So I convert it to a tuple!

@gmuraru perhaps point this PR to one of your branch? Only one commit is mine here
