### PR TITLE
Add sigmoid to torch.nn.functional

### DIFF
--- a/src/sympc/module/nn/__init__.py
+++ b/src/sympc/module/nn/__init__.py
@@ -4,6 +4,7 @@ from .conv import Conv2d
 from .functional import max_pool2d
 from .functional import mse_loss
 from .functional import relu
+from .functional import sigmoid
 from .linear import Linear
 
-__all__ = ["relu", "mse_loss", "max_pool2d", "Linear", "Conv2d"]
+__all__ = ["relu", "sigmoid", "mse_loss", "max_pool2d", "Linear", "Conv2d"]

--- a/src/sympc/module/nn/functional.py
+++ b/src/sympc/module/nn/functional.py
@@ -17,6 +17,24 @@ from sympc.tensor import ShareTensor
 from sympc.utils import parallel_execution
 
 
+def sigmoid(x: MPCTensor) -> MPCTensor:
+    """Sigmoid function.
+
+    Args:
+        x (MPCTensor): The tensor on which we apply the function
+
+    Returns:
+        An MPCTensor which represents the sigmoid applied on the input tensor
+    """
+    from sympc.approximations.sigmoid import sigmoid
+
+    sigmoid_forward = GRAD_FUNCS.get("sigmoid", None)
+    if sigmoid_forward and x.session.autograd_active:
+        return forward(x, sigmoid_forward)
+    res = sigmoid(x)
+    return res
+
+
 def relu(x: MPCTensor) -> MPCTensor:
     """Rectified linear unit function.
 

--- a/tests/sympc/module/nn/functional_test.py
+++ b/tests/sympc/module/nn/functional_test.py
@@ -7,10 +7,24 @@ import torch
 
 import sympc
 from sympc.module.nn import mse_loss
-from sympc.module.nn import relu
+from sympc.module.nn import relu, sigmoid
 from sympc.session import Session
 from sympc.session import SessionManager
 from sympc.tensor import MPCTensor
+
+
+def test_sigmoid(get_clients) -> None:
+    clients = get_clients(2)
+    session = Session(parties=clients)
+    SessionManager.setup_mpc(session)
+
+    secret = torch.Tensor([-2, -1.5, 0, 1, 1.5, 2])
+    mpc_tensor = MPCTensor(secret=secret, session=session)
+
+    res = sigmoid(mpc_tensor)
+    res_expected = torch.sigmoid(secret)
+
+    assert np.allclose(res.reconstruct(), res_expected, atol=1e-1)
 
 
 def test_relu(get_clients) -> None:

--- a/tests/sympc/module/nn/functional_test.py
+++ b/tests/sympc/module/nn/functional_test.py
@@ -7,7 +7,8 @@ import torch
 
 import sympc
 from sympc.module.nn import mse_loss
-from sympc.module.nn import relu, sigmoid
+from sympc.module.nn import relu
+from sympc.module.nn import sigmoid
 from sympc.session import Session
 from sympc.session import SessionManager
 from sympc.tensor import MPCTensor


### PR DESCRIPTION
## Description
This PR adds sigmoid function to torch.nn.functional. The other approximations could also be added in the future when grad functions are made available. 

## How has this been tested?
- Added a unit test for the same

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
