### PR TITLE
Updated the order of flaky tests

### DIFF
--- a/tests/sympc/approximations/softmax_test.py
+++ b/tests/sympc/approximations/softmax_test.py
@@ -10,7 +10,7 @@ from sympc.session import SessionManager
 from sympc.tensor.mpc_tensor import MPCTensor
 
 
-@pytest.mark.order(7)
+@pytest.mark.order(6)
 @pytest.mark.parametrize(
     "dim",
     [None, -2, -1, 0, 1],
@@ -43,7 +43,7 @@ def test_softmax_single_along_dim(get_clients) -> None:
     assert torch.allclose(x_secret_softmax, x_softmax.reconstruct(), atol=1e-2)
 
 
-@pytest.mark.order(8)
+@pytest.mark.order(7)
 @pytest.mark.parametrize(
     "dim",
     [None, -2, -1, 0, 1],

--- a/tests/sympc/grad/grad_functions_test.py
+++ b/tests/sympc/grad/grad_functions_test.py
@@ -588,7 +588,7 @@ def test_grad_relu_backward(get_clients) -> None:
     assert np.allclose(res, expected, rtol=1e-3)
 
 
-@pytest.mark.order(9)
+@pytest.mark.order(8)
 def test_forward(get_clients) -> None:
     model = LinearSyNet(torch)
 
@@ -632,7 +632,7 @@ def test_grad_maxpool_2d_dilation_error(get_clients) -> None:
         GradMaxPool2D.forward({}, x, kernel_size=2, dilation=(1, 2))
 
 
-@pytest.mark.order(10)
+@pytest.mark.order(9)
 def test_grad_maxpool_2d_backward_value_error_indices_shape(get_clients) -> None:
     parties = get_clients(2)
 
@@ -660,7 +660,7 @@ def test_grad_maxpool_2d_backward_value_error_indices_shape(get_clients) -> None
         GradMaxPool2D.backward(ctx, secret.share(parties=parties))
 
 
-@pytest.mark.order(11)
+@pytest.mark.order(10)
 def test_grad_maxpool_2d_backward_value_error_kernel_gt_input(get_clients) -> None:
     parties = get_clients(2)
 
@@ -725,7 +725,7 @@ def test_grad_maxpool_2d_forward_value_error_kernel_gt_input(get_clients) -> Non
         )
 
 
-@pytest.mark.order(13)
+@pytest.mark.order(12)
 @pytest.mark.parametrize("kernel_size, stride, padding", POSSIBLE_CONFIGS_MAXPOOL_2D)
 def test_grad_maxpool_2d_forward(get_clients, kernel_size, stride, padding) -> None:
     parties = get_clients(2)
@@ -764,7 +764,7 @@ def test_grad_maxpool_2d_forward(get_clients, kernel_size, stride, padding) -> N
     assert np.allclose(res, expected, rtol=1e-3)
 
 
-@pytest.mark.order(14)
+@pytest.mark.order(16)
 @pytest.mark.parametrize("kernel_size, stride, padding", POSSIBLE_CONFIGS_MAXPOOL_2D)
 def test_grad_maxpool_2d_backward(get_clients, kernel_size, stride, padding) -> None:
     parties = get_clients(2)

--- a/tests/sympc/module/nn/functional_test.py
+++ b/tests/sympc/module/nn/functional_test.py
@@ -77,7 +77,7 @@ POSSIBLE_CONFIGS_MAXPOOL_2D = [
 ]
 
 
-@pytest.mark.order(12)
+@pytest.mark.order(11)
 @pytest.mark.parametrize("kernel_size, stride, padding", POSSIBLE_CONFIGS_MAXPOOL_2D)
 def test_max_pool2d(get_clients, kernel_size, stride, padding) -> None:
     clients = get_clients(2)
@@ -107,7 +107,7 @@ def test_max_pool2d(get_clients, kernel_size, stride, padding) -> None:
     assert np.allclose(res.reconstruct(), res_expected, atol=1e-4)
 
 
-@pytest.mark.order(14)
+@pytest.mark.order(15)
 def test_max_pool2d_raises_value_error_kernel_gt_input(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)

--- a/tests/sympc/tensor/static_test.py
+++ b/tests/sympc/tensor/static_test.py
@@ -60,7 +60,6 @@ def test_argmax_dim(dim, keepdim, get_clients) -> None:
     assert (res == expected).all(), f"Expected argmax to be {expected}"
 
 
-@pytest.mark.order(5)
 def test_max_multiple_max(get_clients) -> None:
     clients = get_clients(2)
     session = Session(parties=clients)
@@ -89,7 +88,7 @@ def test_max(get_clients) -> None:
     assert res == expected, f"Expected argmax to be {expected}"
 
 
-@pytest.mark.order(6)
+@pytest.mark.order(5)
 @pytest.mark.parametrize("dim, keepdim", itertools.product([0, 1, 2], [True, False]))
 def test_max_dim(dim, keepdim, get_clients) -> None:
     clients = get_clients(2)


### PR DESCRIPTION
## Description
Removed order from as it is not a flaky test `test_max_multiple_max`.
Updated the order of the remaining tests and ordered them sequentially

## Affected Dependencies
None

## How has this been tested?
- Tested on local, the order is updated

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
