### PR TITLE
Pass correct parameters for Conv2d grad

### DIFF
--- a/src/sympc/grads/grad_functions.py
+++ b/src/sympc/grads/grad_functions.py
@@ -557,10 +557,10 @@ class GradConv2d(GradFunc):
         output_padding = torch.nn.grad._grad_input_padding(
             grad_output=torch.empty(grad.shape),
             input_size=x.shape,
-            stride=(stride, stride),
-            padding=(padding, padding),
+            stride=stride,
+            padding=padding,
             kernel_size=weight_size,
-            dilation=(dilation, dilation),
+            dilation=dilation,
         )
 
         input_grad = grad.conv_transpose2d(


### PR DESCRIPTION
## Description
Previously the parameters passed for conv2d grad did not generalize when these parameters were specified as tuples. They only worked when they were integers. This PR solves the issue when specified as integers or tuples. 

