### PR TITLE
Type annotations for Approximations #258

### DIFF
--- a/src/sympc/approximations/exponential.py
+++ b/src/sympc/approximations/exponential.py
@@ -1,7 +1,12 @@
 """function used to calculate exp of a given tensor."""
 
+# stdlib
+from typing import TypeVar
 
-def exp(value: "MPCTensor", iterations: int=8) -> "MPCTensor":
+MPCTensor = TypeVar("MPCTensor")
+
+
+def exp(value: MPCTensor, iterations: int = 8) -> MPCTensor:
     r"""Approximates the exponential function using a limit approximation.
 
     exp(x) = \lim_{n -> infty} (1 + x / n) ^ n

--- a/src/sympc/approximations/exponential.py
+++ b/src/sympc/approximations/exponential.py
@@ -1,7 +1,7 @@
 """function used to calculate exp of a given tensor."""
 
 
-def exp(value, iterations=8):
+def exp(value: "MPCTensor", iterations: int=8) -> "MPCTensor":
     r"""Approximates the exponential function using a limit approximation.
 
     exp(x) = \lim_{n -> infty} (1 + x / n) ^ n
@@ -9,7 +9,7 @@ def exp(value, iterations=8):
     iterations. We then compute (1 + x / n) once and square `d` times.
 
     Args:
-        value: tensor whose exp is to be calculated
+        value (MPCTensor): tensor whose exp is to be calculated
         iterations (int): number of iterations for limit approximation
 
     Ref: https://github.com/LaRiffle/approximate-models

--- a/src/sympc/approximations/log.py
+++ b/src/sympc/approximations/log.py
@@ -1,9 +1,14 @@
 """fucntion used to calculate log of given tensor."""
 
+# stdlib
+from typing import TypeVar
+
 from sympc.approximations.exponential import exp
 
+MPCTensor = TypeVar("MPCTensor")
 
-def log(self: "MPCTensor", iterations: int=2, exp_iterations: int=8) -> "MPCTensor":
+
+def log(self: "MPCTensor", iterations: int = 2, exp_iterations: int = 8) -> "MPCTensor":
     """Approximates the natural logarithm using 8th order modified Householder iterations.
 
         Recall that Householder method is an algorithm to solve a non linear equation f(x) = 0.

--- a/src/sympc/approximations/log.py
+++ b/src/sympc/approximations/log.py
@@ -3,7 +3,7 @@
 from sympc.approximations.exponential import exp
 
 
-def log(self, iterations=2, exp_iterations=8):
+def log(self: "MPCTensor", iterations: int=2, exp_iterations: int=8) -> "MPCTensor":
     """Approximates the natural logarithm using 8th order modified Householder iterations.
 
         Recall that Householder method is an algorithm to solve a non linear equation f(x) = 0.
@@ -14,7 +14,7 @@ def log(self, iterations=2, exp_iterations=8):
             y_{n+1} = y_n - h * (1 + h / 2 + h^2 / 3 + h^3 / 6 + h^4 / 5 + h^5 / 7)
 
     Args:
-        self: tensor whose log has to be calculated
+        self (MPCTensor): tensor whose log has to be calculated
         iterations (int): number of iterations for 6th order modified
             Householder approximation.
         exp_iterations (int): number of iterations for limit approximation of exp

--- a/src/sympc/approximations/reciprocal.py
+++ b/src/sympc/approximations/reciprocal.py
@@ -1,12 +1,19 @@
 """function used to calculate reciprocal of a given tensor."""
 
+# stdlib
+from typing import TypeVar
+
 from sympc.approximations.exponential import exp
 from sympc.approximations.log import log
 from sympc.approximations.utils import modulus
 from sympc.approximations.utils import sign
 
+MPCTensor = TypeVar("MPCTensor")
 
-def reciprocal(self: "MPCTensor", method: str = "NR", nr_iters: int = 10) -> "MPCTensor":
+
+def reciprocal(
+    self: "MPCTensor", method: str = "NR", nr_iters: int = 10
+) -> "MPCTensor":
     r"""Calculate the reciprocal using the algorithm specified in the method args.
 
     Ref: https://github.com/facebookresearch/CrypTen

--- a/src/sympc/approximations/reciprocal.py
+++ b/src/sympc/approximations/reciprocal.py
@@ -6,15 +6,15 @@ from sympc.approximations.utils import modulus
 from sympc.approximations.utils import sign
 
 
-def reciprocal(self, method: str = "NR", nr_iters: int = 10):
+def reciprocal(self: "MPCTensor", method: str = "NR", nr_iters: int = 10) -> "MPCTensor":
     r"""Calculate the reciprocal using the algorithm specified in the method args.
 
     Ref: https://github.com/facebookresearch/CrypTen
 
     Args:
-        self: input data
-        nr_iters: Number of iterations for Newton-Raphson
-        method: 'NR' - `Newton-Raphson`_ method computes the reciprocal using iterations
+        self (MPCTensor): input data
+        nr_iters (int): Number of iterations for Newton-Raphson
+        method (str): 'NR' - `Newton-Raphson`_ method computes the reciprocal using iterations
                 of :math:`x_{i+1} = (2x_i - self * x_i^2)` and uses
                 :math:`3*exp(-(x-.5)) + 0.003` as an initial guess by default
 
@@ -22,7 +22,7 @@ def reciprocal(self, method: str = "NR", nr_iters: int = 10):
                         :math:`x^{-1} = exp(-log(x))`
 
     Returns:
-        Reciprocal of `self`
+        MPCTensor : Reciprocal of `self`
 
     Raises:
         ValueError: if the given method is not supported

--- a/src/sympc/approximations/sigmoid.py
+++ b/src/sympc/approximations/sigmoid.py
@@ -1,6 +1,4 @@
 """function used to calculate sigmoid of a given tensor."""
-# stdlib
-from typing import Any
 
 # third party
 import torch
@@ -10,16 +8,16 @@ from sympc.approximations.reciprocal import reciprocal
 from sympc.approximations.utils import sign
 
 
-def sigmoid(tensor: Any, method: str = "exp") -> Any:
+def sigmoid(tensor: "MPCTensor", method: str = "exp") -> "MPCTensor":
     """Approximates the sigmoid function using a given method.
 
     Args:
-        tensor (Any): tensor to calculate sigmoid
+        tensor (MPCTensor): tensor to calculate sigmoid
         method (str): (default = "chebyshev")
             Possible values: "exp", "maclaurin", "chebyshev"
 
     Returns:
-        tensor (Any): the calulated sigmoid value
+        MPCTensor: the calulated sigmoid value
 
     Raises:
         ValueError: if the given method is not supported

--- a/src/sympc/approximations/sigmoid.py
+++ b/src/sympc/approximations/sigmoid.py
@@ -1,11 +1,16 @@
 """function used to calculate sigmoid of a given tensor."""
 
+# stdlib
+from typing import TypeVar
+
 # third party
 import torch
 
 from sympc.approximations.exponential import exp
 from sympc.approximations.reciprocal import reciprocal
 from sympc.approximations.utils import sign
+
+MPCTensor = TypeVar("MPCTensor")
 
 
 def sigmoid(tensor: "MPCTensor", method: str = "exp") -> "MPCTensor":

--- a/src/sympc/approximations/tanh.py
+++ b/src/sympc/approximations/tanh.py
@@ -15,14 +15,14 @@ from sympc.tensor import MPCTensor
 from sympc.tensor.static import stack
 
 
-def _tanh_sigmoid(tensor):
+def _tanh_sigmoid(tensor: MPCTensor) -> MPCTensor:
     """Compute the tanh using the sigmoid approximation.
 
     Args:
-        tensor (tensor): values where tanh should be approximated
+        tensor (MPCTensor): values where tanh should be approximated
 
     Returns:
-        tensor (tensor): tanh calculated using sigmoid
+        MPCTensor: tanh calculated using sigmoid
     """
     return 2 * sigmoid(2 * tensor) - 1
 

--- a/src/sympc/approximations/utils.py
+++ b/src/sympc/approximations/utils.py
@@ -1,5 +1,10 @@
 """Utility functions for approximation functions."""
-from sympc.tensor import MPCTensor
+
+# stdlib
+from typing import TypeVar
+
+MPCTensor = TypeVar("MPCTensor")
+
 
 def sign(data: MPCTensor) -> MPCTensor:
     """Calculate sign of given tensor.

--- a/src/sympc/approximations/utils.py
+++ b/src/sympc/approximations/utils.py
@@ -1,11 +1,11 @@
 """Utility functions for approximation functions."""
+from sympc.tensor import MPCTensor
 
-
-def sign(data):
+def sign(data: MPCTensor) -> MPCTensor:
     """Calculate sign of given tensor.
 
     Args:
-        data: tensor whose sign has to be determined
+        data (MPCTensor): tensor whose sign has to be determined
 
     Returns:
         MPCTensor: tensor with the determined sign
@@ -13,11 +13,11 @@ def sign(data):
     return (data > 0) + (data < 0) * (-1)
 
 
-def modulus(data):
+def modulus(data: MPCTensor) -> MPCTensor:
     """Calculation of modulus for a given tensor.
 
     Args:
-        data(MPCTensor): tensor whose modulus has to be calculated
+        data (MPCTensor): tensor whose modulus has to be calculated
 
     Returns:
         MPCTensor: the required modulus


### PR DESCRIPTION
## Description

Added type annotations to the approximations module of SyMPC:

 - [x] exponential.py
 - [x] log.py
 - [x] reciprocal.py
 - [x] sigmoid.py
 - [x] softmax.py
 - [x] tanh.py
 - [x] utils.py

It resolves issue #258.

## Affected Dependencies
None.

## How has this been tested?
- Tested each function individually in a jupyter notebook.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labelled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests

