### PR TITLE
`cat` concatenates `ReplicatedSharedTensor`

### DIFF
--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ If you are new to the project and want to get into the code, we recommend pickin
 Before you get started you will need a few things installed depending on your operating system.
 
 - OS Package Manager
-- Python 3.7+
+- Python 3.8+
 - git
 
 ### OSes
@@ -117,7 +117,7 @@ $ brew install git
 
 ## Python Versions
 
-This project supports Python 3.7+, however, if you are contributing it can help to be able to switch between python versions to fix issues or bugs that relate to a specific python version. Depending on your operating system there are a number of ways to install different versions of python however one of the easiest is with the `pyenv` tool. Additionally, as we will be frequently be installing and changing python packages for this project we should isolate it from your system python and other projects you have using a virtualenv.
+This project supports Python 3.8+, however, if you are contributing it can help to be able to switch between python versions to fix issues or bugs that relate to a specific python version. Depending on your operating system there are a number of ways to install different versions of python however one of the easiest is with the `pyenv` tool. Additionally, as we will be frequently be installing and changing python packages for this project we should isolate it from your system python and other projects you have using a virtualenv.
 
 ### MacOS
 
@@ -152,10 +152,10 @@ $  pyenv install --list | grep 3.9
 3.9.4
 ```
 
-Wow, there are lots of options, lets install 3.7.
+Wow, there are lots of options, lets install 3.8.
 
 ```
-$ pyenv install 3.7.9
+$ pyenv install 3.8.0
 ```
 
 Now, lets see what versions are installed:
@@ -461,7 +461,7 @@ $ pydocstyle .
 
 ### Imports Formatting
 
-We use isort to automatically format the python imports. 
+We use isort to automatically format the python imports.
 Run isort manually like this:
 
 ```

--- a/src/sympc/api.py
+++ b/src/sympc/api.py
@@ -262,6 +262,10 @@ replicated_shared_tensor_attrs = [
         "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor.repeat",
         "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
+    (
+        "sympc.tensor.static.cat_replicatedShare_tensor", 
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor"
+    ),
 ]
 
 allowed_external_attrs = [

--- a/src/sympc/api.py
+++ b/src/sympc/api.py
@@ -263,8 +263,8 @@ replicated_shared_tensor_attrs = [
         "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
     (
-        "sympc.tensor.static.cat_replicatedShare_tensor", 
-        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor"
+        "sympc.tensor.static.cat_replicatedShare_tensor",
+        "sympc.tensor.replicatedshare_tensor.ReplicatedSharedTensor",
     ),
 ]
 

--- a/src/sympc/protocol/falcon/falcon.py
+++ b/src/sympc/protocol/falcon/falcon.py
@@ -545,7 +545,13 @@ class Falcon(metaclass=Protocol):
             c[i] = u[i] + 1 + w
             w += x[i] ^ r_i
 
-        d = m * math.prod(c)
+        try:
+            d = m * math.prod(c)
+        except AttributeError:
+            prod = 1
+            for i in c:
+                prod *= i
+            d = m * prod
 
         d_val = d.reconstruct(decode=False)  # plaintext d.
         d_val[d_val != 0] = 1  # making all non zero values as 1.

--- a/src/sympc/protocol/falcon/falcon.py
+++ b/src/sympc/protocol/falcon/falcon.py
@@ -545,13 +545,7 @@ class Falcon(metaclass=Protocol):
             c[i] = u[i] + 1 + w
             w += x[i] ^ r_i
 
-        try:
             d = m * math.prod(c)
-        except AttributeError:
-            prod = 1
-            for i in c:
-                prod *= i
-            d = m * prod
 
         d_val = d.reconstruct(decode=False)  # plaintext d.
         d_val[d_val != 0] = 1  # making all non zero values as 1.

--- a/src/sympc/tensor/static.py
+++ b/src/sympc/tensor/static.py
@@ -18,7 +18,9 @@ import torch
 from sympc.session import get_session
 from sympc.tensor.mpc_tensor import MPCTensor
 from sympc.tensor.share_tensor import ShareTensor
+from sympc.tensor.replicatedshare_tensor import ReplicatedSharedTensor
 from sympc.utils import parallel_execution
+import sympc.protocol as protocol
 
 
 def stack(tensors: List, dim: int = 0) -> MPCTensor:
@@ -90,8 +92,10 @@ def cat(tensors: List, dim: int = 0) -> MPCTensor:
         )
     )
 
-    stack_shares = parallel_execution(cat_share_tensor, session.parties)(args)
-    from sympc.tensor import MPCTensor
+    if isinstance(session.protocol, protocol.FSS):
+        stack_shares = parallel_execution(cat_share_tensor, session.parties)(args)
+    elif isinstance(session.protocol, protocol.Falcon):
+        stack_shares = parallel_execution(cat_replicatedShare_tensor, session.parties)(args)
 
     expected_shape = torch.cat(
         [torch.empty(each_tensor.shape) for each_tensor in tensors], dim=dim
@@ -117,6 +121,27 @@ def cat_share_tensor(session_uuid_str: str, *shares: Tuple[ShareTensor]) -> Shar
     result.tensor = torch.cat([share.tensor for share in shares])
     return result
 
+def cat_replicatedShare_tensor(session_uuid_str: str, *shares: Tuple[ReplicatedSharedTensor]) -> ReplicatedSharedTensor:
+    """Helper method that performs torch.cat on the replicated shares of the Tensors.
+
+    Args:
+        session_uuid_str (str): UUID to identify the session on each party side.
+        shares (Tuple[ShareTensor]): Replicated shares of the tensors to be concatenated.
+
+    Returns:
+        ReplicatedSharedTensor: Respective replicated shares after concatenation
+    """
+    
+    session = get_session(session_uuid_str)
+    result = ReplicatedSharedTensor(session_uuid=UUID(session_uuid_str), config=session.config)
+    
+    cat_result = [torch.tensor([]).type(torch.LongTensor) for _ in range(len(shares[0].shares))]
+    for share in shares:
+      for i in range(len(shares[0].shares)):
+        cat_result[i] = torch.cat([cat_result[i],share.shares[i]])
+
+    result.shares = cat_result
+    return result
 
 def helper_argmax(
     x: MPCTensor,


### PR DESCRIPTION
## Description
- refer to issue #324
- `cat` can concatenates `ShareTensor`, but it is not workable for `ReplicatedSharedTensor`.
- added `cat_replicatedShare_tensor` in *apy.py* and *static.py* for the concatenation of `ReplicatedSharedTensor`.

## Affected Dependencies

## How has this been tested?

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests