### PR TITLE
Add benchmark link to README.rst Fixes #142

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@
     <a href=""><img src="https://github.com/OpenMined/SyMPC/actions/workflows/tests.yml/badge.svg" /></a>
     <a href="https://openmined.slack.com/messages/support"><img src="https://img.shields.io/badge/chat-on%20slack-7A5979.svg" /></a>
     <a href="https://codecov.io/gh/OpenMined/SyMPC"><img src="https://codecov.io/gh/OpenMined/SyMPC/branch/main/graph/badge.svg?token=TS2rZyJRlo" /></a>
-
+    <a href="https://openmined.github.io/SyMPC/dev/bench/"><img src="https://img.shields.io/badge/benchmarks-view-blue" /></a>
 
 SyMPC **/ˈsɪmpəθi/** is a library which extends `PySyft <https://github.com/OpenMined/PySyft>`_ ≥0.3 with SMPC support. It allows computing over encrypted data, and to train and evaluate neural networks.
 
@@ -82,6 +82,12 @@ SyMPC supports the following protocols.
 
 We can see other interesting information about the supported operations and Neural
 Network layers in `Supported operations and Neural Network layers <SUPPORTED_OPS.rst>`_.
+
+Benchmarks
+##########
+
+We track the performance of our cryptographic protocols.  You can check the latest benchmarks on our
+`benchmark page <https://openmined.github.io/SyMPC/dev/bench/>`_.
 
 
 Contributing


### PR DESCRIPTION
## Description 
This PR adds a link to the benchmarks on the GitHub Page, making it easier for users to check how the library is performing regarding communication and computation. 

**Changes made:**
- Added a benchmark badge in the header section (alongside existing badges)
- Added a new "Benchmarks" section with a link to the benchmark page at https://openmined.github.io/SyMPC/dev/bench/

Fixes #142

## Affected Dependencies
None.  This is a documentation-only change to `README.rst`.

## How has this been tested?
- Verified that the benchmark URL (https://openmined.github.io/SyMPC/dev/bench/) is accessible and displays benchmark data correctly
- Verified that the badge renders properly using shields.io format
- Confirmed RST syntax is correct and consistent with existing README formatting

**To verify:**
1. Check that the benchmark link in the new section works
2. Check that the badge displays and links correctly
3. Preview the README.rst to ensure proper rendering

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE. md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests